### PR TITLE
feat: add PitClaw side project to now page

### DIFF
--- a/.specs/003-now-pitclaw.md
+++ b/.specs/003-now-pitclaw.md
@@ -1,0 +1,31 @@
+# 003: Add PitClaw to Now Page
+
+**Branch**: `feature/now-pitclaw`
+**Created**: 2026-02-19
+
+## Summary
+
+Add a link to the PitClaw side project on the /now/ page. PitClaw is an ESP32-S3 BBQ temperature controller with a touchscreen and Wi-Fi, hosted at https://github.com/MrMatt57/pitclaw.
+
+## Requirements
+
+- Add PitClaw as a linked item in the "Side Projects" section of `content/now/index.md`
+- Link to the GitHub repo: https://github.com/MrMatt57/pitclaw
+- Keep the description brief and consistent with the page's tone
+- Keep the existing site rebuild bullet point
+
+## Design
+
+Add a second line to the "Side Projects" section with a short description of PitClaw and a link to the repo. The description should be concise — something like "PitClaw — an ESP32-based BBQ temperature controller" with a link on the project name.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `content/now/index.md` | Add PitClaw entry to the Side Projects section |
+
+## Test Plan
+
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [ ] /now/ page renders correctly on localhost (`hugo server -D`)
+- [x] PitClaw link points to https://github.com/MrMatt57/pitclaw

--- a/content/now/index.md
+++ b/content/now/index.md
@@ -14,6 +14,8 @@ Building things with cloud infrastructure and AI.
 
 Rebuilding this site from the ground up with Hugo and Cloudflare Pages.
 
+[PitClaw](https://github.com/MrMatt57/pitclaw) — a spec-driven, agentic engineering project where the software, hardware design, and 3D-printed enclosure are all AI-generated from specs — no code written by hand. ESP32-based smoker controller with a touchscreen web UI, predictive temperature modeling, and a passion for barbecue holding it all together.
+
 ## Interests
 
 Rowing, coffee, cooking, and the occasional homelab tinkering.


### PR DESCRIPTION
## Summary
- Add PitClaw ESP32 BBQ controller as a side project on the /now/ page
- Link to https://github.com/MrMatt57/pitclaw
- Description highlights spec-driven, agentic engineering approach — software, hardware, and 3D printing all AI-generated from specs

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [ ] /now/ page renders correctly on localhost (`hugo server -D`)
- [x] PitClaw link points to https://github.com/MrMatt57/pitclaw

Generated with [Claude Code](https://claude.com/claude-code)