### PR TITLE
chore: track .claude/commands and clean up .gitignore

### DIFF
--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -109,9 +109,21 @@ After implementing, verify the test plan items from the spec:
 
 **Check off test plan items in the spec**: As you verify each test plan item, edit the spec file in the worktree to change `- [ ]` to `- [x]` for that item. The spec should reflect the actual verification status — only check off items you've confirmed pass. Leave items unchecked if they genuinely weren't verified.
 
-## Step 9: Report and Offer to Ship
+## Step 9: Start Dev Server
 
-Print a summary of what was implemented, then ask:
+After implementation is complete, initialize the theme submodule and start the Hugo dev server so the user can preview the changes:
+
+```bash
+cd ../mrmatt-{name}
+git submodule update --init --recursive
+hugo server -D
+```
+
+Run the server in the background and provide the user with the localhost URL to verify.
+
+## Step 10: Report and Offer to Ship
+
+Print a summary of what was implemented, provide the localhost URL for review, then ask:
 
 > Done! Want me to `/ship` it?
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
 public/
 resources/
 .hugo_build.lock
-node_modules/
-.claude/
-CLAUDE.md

--- a/.specs/005-track-claude-config.md
+++ b/.specs/005-track-claude-config.md
@@ -1,0 +1,44 @@
+# 005: Track .claude/ and CLAUDE.md in Git
+
+**Branch**: `feature/track-claude-config`
+**Created**: 2026-02-19
+
+## Summary
+
+Remove `.claude/`, `CLAUDE.md`, and `node_modules/` from `.gitignore` so that Claude Code commands and project instructions are version-controlled. Also removes the stale `node_modules/` entry since the project has no npm dependencies.
+
+## Requirements
+
+- Remove `.claude/` from `.gitignore`
+- Remove `CLAUDE.md` from `.gitignore`
+- Remove `node_modules/` from `.gitignore` (no npm deps in project)
+- Commit `.claude/commands/` (feature.md, ship.md, setup.md) so they're tracked
+- Commit `CLAUDE.md` so project instructions are tracked
+- Do NOT commit `.claude/settings.json` or other local config — only commands
+
+## Design
+
+Edit `.gitignore` to remove the three entries. Then `git add` the command files and CLAUDE.md. Add a selective ignore for `.claude/` local state files that shouldn't be tracked (settings, cache, etc.) by only tracking `.claude/commands/`.
+
+Updated `.gitignore`:
+```
+public/
+resources/
+.hugo_build.lock
+```
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `.gitignore` | Remove `.claude/`, `CLAUDE.md`, and `node_modules/` entries |
+| `.claude/commands/feature.md` | Now tracked (already exists) |
+| `.claude/commands/ship.md` | Now tracked (already exists, includes recent bug fixes) |
+| `.claude/commands/setup.md` | Now tracked (already exists) |
+| `CLAUDE.md` | Now tracked (already exists) |
+
+## Test Plan
+
+- [x] `.claude/commands/` files are tracked in git
+- [x] `CLAUDE.md` is tracked in git
+- [x] Hugo builds with no errors (`hugo --minify`)


### PR DESCRIPTION
## Summary
- Remove `.claude/`, `CLAUDE.md`, and `node_modules/` from `.gitignore`
- Version-control custom Claude Code commands (`/feature`, `/ship`, `/setup`)
- Includes recent `/ship` worktree cleanup bug fixes and `/feature` dev server step

## Test plan
- [x] `.claude/commands/` files are tracked in git
- [x] `CLAUDE.md` is tracked in git
- [x] Hugo builds with no errors (`hugo --minify`)

Generated with [Claude Code](https://claude.com/claude-code)