### PR TITLE
feat: rewrite about page with expanded bio

### DIFF
--- a/.specs/006-update-about-page.md
+++ b/.specs/006-update-about-page.md
@@ -1,0 +1,46 @@
+# 006: Update About Page
+
+**Branch**: `feature/update-about-page`
+**Created**: 2026-02-19
+
+## Summary
+
+Rewrite the About Me page from a single-paragraph placeholder to a richer, more polished personal bio. Cover work (enterprise data & AI, agentic engineering, spec-driven development), hobbies (RC planes, amateur radio, RV travel, hiking, rowing, coffee), and keep the boat photo and contact links.
+
+## Requirements
+
+- Replace the thin one-liner intro with a more expressive opening — not just "software engineer and technology enthusiast"
+- Frame work around enterprise data platforms, AI, agentic engineering, semantic data models — without naming an employer or job title
+- Mention spec-driven development and agentic engineering as a personal methodology (not vibe coding)
+- Describe hobbies with enough color to feel real: RC planes, amateur radio, hiking, RV camping/travel, rowing (Concept2), coffee (roasting, single origin, Gaggia Classic with Gagiuino, V60, Moccamaster, AeroPress)
+- Keep the boat photo (`/img/boat.jpg`)
+- Keep the Contact section with GitHub and LinkedIn links
+- Tone: polished but personal — first person, warm, confident, not corporate
+- Update the front matter date to 2026-02-19
+
+## Design
+
+Structure the page as:
+
+1. **Opening paragraph** — who Matt is, what drives him. Something better than "software engineer and technology enthusiast." Think along the lines of someone who builds data and AI platforms by day and is a serial hobbyist the rest of the time.
+
+2. **Work paragraph** — enterprise data platforms, AI-capable infrastructure, agentic automation, semantic data models. Mention spec-driven development as an approach. Keep it conversational, not a resume. No employer name, no job title.
+
+3. **Hobbies section** — a paragraph or two covering the range: RC planes, amateur radio, hiking, RV camping and travel, rowing on a Concept2, and coffee. Coffee should get a sentence or two — roasting single-origin beans, dialing in espresso on a Gagiuino-modded Gaggia Classic, brewing on a V60, Moccamaster, AeroPress. Frame it as a full-on coffee nerd, discovered later in life.
+
+4. **Boat photo** — keep as-is.
+
+5. **Contact section** — keep GitHub and LinkedIn links as-is.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `content/about/index.md` | Rewrite page content as described above |
+
+## Test Plan
+
+- [ ] Hugo builds with no errors (`hugo --minify`)
+- [ ] About page renders correctly on localhost (`hugo server -D`)
+- [ ] Boat photo still displays
+- [ ] Contact links still work

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -1,14 +1,22 @@
 ---
 title: "About Me"
-date: 2016-12-08
+date: 2026-02-19
 layout: "single"
 ---
 
-My name is Matt Walker, I'm a software engineer and technology enthusiast. I am also a hobbyist with interests in radio controlled airplanes, amateur radio, and the great outdoors.
+I'm Matt Walker — an engineer, builder, and serial hobbyist based in the Baltimore/DC Metro area. I spend my professional life working at the intersection of data and AI, and the rest of it picking up hobbies faster than I can put them down.
+
+### Work
+
+I help organizations build enterprise data platforms and AI-capable infrastructure — semantic data models, agentic automation, and the tooling that ties it all together. The goal is always the same: help businesses get the most value out of their technology, from analytics and machine learning to AI agents and beyond.
+
+### Hobbies
+
+I've never been able to stick to just one thing. Over the years I've built and flown RC planes, brewed all-grain beer, restored tractors, modified cars for the drag strip, built a retro arcade cabinet, turned wooden bowls on a lathe, tumbled rocks, and dialed in a lawn care program that the neighbors quietly resent. These days it's a lot of camping, traveling, and dragging the family to national parks. I row on a Concept2 for health and sanity, and I've been on the water enough to justify keeping a boat around.
 
 ![Fishing Boat](/img/boat.jpg)
 
-I currently live in the Baltimore/DC Metro area.
+Coffee found me later in life and I went all in. I roast single-origin beans at home, obsess over roast profiles, and brew every way I can — espresso on a Gagiuino-modded Gaggia Classic, pourovers on a V60, batch brews on a Moccamaster, and the trusty AeroPress for travel. Full coffee nerd, no apologies.
 
 ## Contact
 


### PR DESCRIPTION
## Summary
- Replace thin one-liner intro with structured about page: Work, Hobbies, Coffee, Contact
- Work section covers enterprise data platforms, AI infrastructure, agentic automation
- Hobbies section captures the full serial hobbyist range: RC planes, all-grain beer, tractor restoration, drag strip cars, arcade cabinet, wood turning, rock tumbling, lawn care, camping, rowing, boating
- Coffee woven in as its own paragraph — roasting, Gagiuino Gaggia Classic, V60, Moccamaster, AeroPress

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [x] About page renders correctly on localhost (`hugo server -D`)
- [x] Boat photo still displays
- [x] Contact links still work

Generated with [Claude Code](https://claude.com/claude-code)