### PR TITLE
feat: stack home page avatar and text on small screens

### DIFF
--- a/.specs/007-home-responsive-wrap.md
+++ b/.specs/007-home-responsive-wrap.md
@@ -1,0 +1,34 @@
+# 007: Home Page Responsive Text Wrap
+
+**Branch**: `feature/home-responsive-wrap`
+**Created**: 2026-02-20
+
+## Summary
+
+On the home page, the avatar and bio text sit side by side using flexbox. On desktop this looks great, but on smaller screens the text gets squeezed next to the 175px avatar. Add a responsive breakpoint so the layout stacks vertically (avatar on top, text below) on mobile/small screens.
+
+## Requirements
+
+- On viewports >= 550px: keep current side-by-side layout (avatar left, text right)
+- On viewports < 550px: stack avatar above text, center the avatar
+- Use the existing 550px breakpoint already established in `custom.css`
+- Works in both light and dark mode
+- No changes to HTML template
+
+## Design
+
+Add a `@media (max-width: 549px)` query targeting `.home-about` to switch `flex-direction` to `column` and center the avatar. This is a CSS-only change — no template modifications needed.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `assets/css/extended/custom.css` | Add responsive media query for `.home-about` section |
+
+## Test Plan
+
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [ ] Desktop (>= 550px): avatar and text remain side by side
+- [ ] Mobile (< 550px): layout stacks vertically, avatar centered above text
+- [ ] Dark mode: layout behaves the same
+- [ ] No horizontal overflow on small screens

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -180,6 +180,13 @@ h6 { font-size: 1rem; line-height: 1.6; letter-spacing: 0; margin-bottom: 0.25em
     margin-bottom: 0;
 }
 
+@media (max-width: 549px) {
+    .home-about {
+        flex-direction: column;
+        align-items: center;
+    }
+}
+
 /* ===== Homepage: journal section ===== */
 
 .home-journal {


### PR DESCRIPTION
## Summary
- On the home page, the avatar and bio text use flexbox side by side — on narrow screens the text gets squeezed next to the 175px avatar
- Added a CSS media query at 549px to switch the layout to stacked (avatar centered above text) on mobile/small screens
- CSS-only change, no template modifications

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [ ] Desktop (>= 550px): avatar and text remain side by side
- [ ] Mobile (< 550px): layout stacks vertically, avatar centered above text
- [ ] Dark mode: layout behaves the same
- [ ] No horizontal overflow on small screens

Generated with [Claude Code](https://claude.com/claude-code)