### PR TITLE
fix: hanging indent for bullet list wrapped text

### DIFF
--- a/.specs/008-fix-list-bullet-indent.md
+++ b/.specs/008-fix-list-bullet-indent.md
@@ -1,0 +1,43 @@
+# 008: Fix List Bullet Text Indent on Wrap
+
+**Branch**: `feature/fix-list-bullet-indent`
+**Created**: 2026-02-20
+
+## Summary
+
+When list items in the `.posts` bullet list wrap to a second line, the wrapped text aligns with the bullet character instead of with the text start. This affects the home page journal list, tag pages, and the archives page. The fix adds a hanging indent so wrapped text stays aligned with the first line's text.
+
+## Requirements
+
+- Wrapped text in `.posts li` items must align with the text start, not the bullet
+- The square bullet (`\25AA`) must remain visually in the same position
+- Fix must apply globally to all `.posts` lists (home page, tags, tag, archives)
+- Dark mode styling must continue to work correctly
+- No changes to HTML templates — CSS-only fix
+
+## Design
+
+The current CSS uses a `::before` pseudo-element for the bullet with `margin-right: 0.5em`, but the `<li>` has no left padding to create a hanging indent. When text wraps, it flows back to the left edge (position 0), under the bullet.
+
+**Fix approach:** Use `padding-left` on the `<li>` with `position: relative`, then absolutely position the `::before` bullet in the reserved left padding space. This creates a proper hanging indent where wrapped text aligns with the first line's text.
+
+Changes to `assets/css/extended/custom.css`:
+
+1. Add `padding-left: 1.2em` and `position: relative` to `.posts li`
+2. Change `.posts li::before` to use `position: absolute; left: 0` and remove `margin-right`
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `assets/css/extended/custom.css` | Update `.posts li` and `.posts li::before` rules for hanging indent |
+
+## Test Plan
+
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [x] Site renders correctly on localhost (`hugo server -D`)
+- [ ] Home page journal list: long titles wrap with text aligned to text start, not bullet
+- [ ] Tag page list: same wrapping behavior
+- [ ] Archives page list: same wrapping behavior
+- [ ] Dark mode: bullets and text still styled correctly
+- [ ] Short titles that don't wrap are unaffected visually

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -231,11 +231,14 @@ h6 { font-size: 1rem; line-height: 1.6; letter-spacing: 0; margin-bottom: 0.25em
     list-style: none;
     margin-bottom: 0.5em;
     margin-left: 0;
+    padding-left: 1.2em;
+    position: relative;
 }
 
 .posts li::before {
     content: "\25AA";
-    margin-right: 0.5em;
+    position: absolute;
+    left: 0;
     color: #090909;
 }
 


### PR DESCRIPTION
## Summary
- When `.posts` list items wrap to a second line, wrapped text now aligns with the text start instead of going back to the bullet character
- Uses absolute positioning on the `::before` pseudo-element bullet with `padding-left` on the `<li>` to create a proper hanging indent
- Affects all `.posts` lists site-wide: home page journal, tags, individual tag pages, and archives

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [x] Site renders correctly on localhost (`hugo server -D`)
- [ ] Home page journal list: long titles wrap with text aligned to text start, not bullet
- [ ] Tag page list: same wrapping behavior
- [ ] Archives page list: same wrapping behavior
- [ ] Dark mode: bullets and text still styled correctly
- [ ] Short titles that don't wrap are unaffected visually

Generated with [Claude Code](https://claude.com/claude-code)