### PR TITLE
fix: read OAuth client ID from environment at runtime

### DIFF
--- a/.specs/011-pwa-oauth-client-id.md
+++ b/.specs/011-pwa-oauth-client-id.md
@@ -1,0 +1,36 @@
+# 011: PWA OAuth Client ID from Environment
+
+**Branch**: `feature/pwa-oauth-client-id`
+**Created**: 2026-02-24
+
+## Summary
+
+The PWA upload page hardcodes `GITHUB_CLIENT_ID` as a placeholder in the login button's `data-client-id` attribute. Since the upload page is static HTML served from `static/upload/`, it cannot read Cloudflare Pages environment variables directly. Add a small API endpoint that returns the client ID so the JavaScript can fetch it at runtime.
+
+## Requirements
+
+- Remove the hardcoded `data-client-id="GITHUB_CLIENT_ID"` placeholder from the login button
+- Create a Cloudflare Pages Function (`functions/api/oauth-client-id.js`) that reads `GITHUB_CLIENT_ID` from the environment and returns it as JSON
+- Update `app.js` to fetch the client ID from the API before building the OAuth redirect URL
+- Handle the case where `GITHUB_CLIENT_ID` is not configured (show an error)
+
+## Design
+
+New API endpoint: `GET /api/oauth-client-id` returns `{ "client_id": "..." }`.
+
+The login button click handler fetches the client ID from the API, then redirects to GitHub OAuth. If the fetch fails or the client ID is missing, show an error status message.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `functions/api/oauth-client-id.js` | CREATE — New endpoint returning `GITHUB_CLIENT_ID` from env |
+| `static/upload/index.html` | Remove `data-client-id` placeholder from login button |
+| `static/upload/app.js` | Fetch client ID from API instead of reading `data-client-id` |
+
+## Test Plan
+
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [x] Login button no longer has hardcoded placeholder client ID
+- [ ] `/api/oauth-client-id` endpoint returns JSON with client_id from environment
+- [ ] Clicking "Log in with GitHub" fetches client ID and redirects to correct GitHub OAuth URL

--- a/functions/api/oauth-client-id.js
+++ b/functions/api/oauth-client-id.js
@@ -1,0 +1,15 @@
+export async function onRequestGet(context) {
+    var clientId = context.env.GITHUB_CLIENT_ID;
+
+    if (!clientId) {
+        return new Response(JSON.stringify({ error: 'OAuth not configured' }), {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' }
+        });
+    }
+
+    return new Response(JSON.stringify({ client_id: clientId }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+    });
+}

--- a/static/upload/index.html
+++ b/static/upload/index.html
@@ -18,7 +18,7 @@
 
     <div id="auth-section" class="auth-section">
         <p style="margin-bottom: 1rem;">Log in with GitHub to upload photos to the gallery.</p>
-        <button id="login-btn" class="btn btn-primary" data-client-id="GITHUB_CLIENT_ID">Log in with GitHub</button>
+        <button id="login-btn" class="btn btn-primary">Log in with GitHub</button>
     </div>
 
     <div id="upload-form" class="upload-form">


### PR DESCRIPTION
## Summary
- The PWA upload login button had a hardcoded `GITHUB_CLIENT_ID` placeholder causing a 404 on GitHub's OAuth page
- Added a new Cloudflare Pages Function (`/api/oauth-client-id`) that returns the client ID from the environment
- Login button now fetches the client ID at click time instead of reading a static `data-` attribute

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [x] Login button no longer has hardcoded placeholder client ID
- [ ] `/api/oauth-client-id` endpoint returns JSON with client_id from environment
- [ ] Clicking "Log in with GitHub" fetches client ID and redirects to correct GitHub OAuth URL

Generated with [Claude Code](https://claude.com/claude-code)