### PR TITLE
fix: add deploy concurrency to prevent race conditions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- PWA photo uploads create two rapid commits (photo file, then metadata), both triggering simultaneous deploys
- The slower first deploy can finish last and overwrite the complete build, causing the photo to disappear from the site
- Adds a `concurrency` group with `cancel-in-progress: true` so only the latest commit's deploy runs

## Test plan
- [x] Workflow YAML is valid
- [ ] Two rapid pushes to main result in only one deploy (second cancels first)

Generated with [Claude Code](https://claude.com/claude-code)