### PR TITLE
feat: smooth lightbox transitions when image size changes

### DIFF
--- a/.specs/012-smooth-lightbox-resize.md
+++ b/.specs/012-smooth-lightbox-resize.md
@@ -1,0 +1,51 @@
+# 012: Smooth Lightbox Resize Transitions
+
+**Branch**: `feature/smooth-lightbox-resize`
+**Created**: 2026-02-24
+
+## Summary
+
+When navigating between photos in the lightbox, the image size changes cause a visible jolt — the title, rule, and description jump as the image wrapper resizes. Fix this by fading the entire content area (image + metadata) together so all layout shifts happen while the content is invisible.
+
+## Requirements
+
+- When navigating between photos, the entire image+metadata area should fade out, swap content, then fade in
+- Title, description, and rule text should update during the invisible phase (not before)
+- No visible layout shift during the transition
+- First-open (clicking a thumbnail) should still fade in cleanly without an unnecessary fade-out delay
+- Works on both the homepage lightbox and the /photography/ page lightbox
+
+## Design
+
+Currently only the `<img>` element fades via `.lightbox-img-loading`. The title/description update immediately (visible jump) and the image wrapper resizes at opacity 0 but the text below is still visible.
+
+**Fix**: Fade the `.lightbox-img-and-meta` wrapper instead of just the image. This contains the image, title, rule, and description — everything that changes between photos. Move all content updates (src, alt, title, description, rule width) into the post-fade callback so they happen while invisible.
+
+### CSS Changes
+- Add `transition: opacity 0.15s ease` to `.lightbox-img-and-meta`
+- Add `.lightbox-img-and-meta.lightbox-transitioning { opacity: 0; }`
+- Remove `transition` from `.lightbox-img` (no longer needed for navigation)
+- Remove `.lightbox-img.lightbox-img-loading` (replaced by wrapper class)
+
+### JS Changes (both `layouts/index.html` and `layouts/photography/list.html`)
+- Get reference to `.lightbox-img-and-meta` element
+- In `showPhoto()`: move title/description/rule updates into the `applyImage` callback
+- Replace `img.classList.add/remove('lightbox-img-loading')` with `imgAndMeta.classList.add/remove('lightbox-transitioning')`
+- Nav visibility and hash updates can stay immediate (invisible during fade)
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `assets/css/extended/custom.css` | Add transition to `.lightbox-img-and-meta`, add `.lightbox-transitioning` class, remove image-level loading styles |
+| `layouts/index.html` | Update lightbox JS to fade wrapper instead of image |
+| `layouts/photography/list.html` | Update lightbox JS to fade wrapper instead of image |
+
+## Test Plan
+
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [ ] Clicking a thumbnail opens lightbox with smooth fade-in (no delay)
+- [ ] Navigating between photos fades entire content area (no visible layout jump)
+- [ ] Title, description, and rule update during invisible phase
+- [ ] Keyboard navigation (arrow keys) also transitions smoothly
+- [ ] Close/escape still works correctly on both pages

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -430,11 +430,6 @@ h6 { font-size: 1rem; line-height: 1.6; letter-spacing: 0; margin-bottom: 0.25em
     max-height: 100%;
     object-fit: contain;
     border-radius: 4px;
-    transition: opacity 0.15s ease;
-}
-
-.lightbox-img.lightbox-img-loading {
-    opacity: 0;
 }
 
 .lightbox-close {
@@ -480,6 +475,11 @@ h6 { font-size: 1rem; line-height: 1.6; letter-spacing: 0; margin-bottom: 0.25em
     justify-content: center;
     min-height: 0;
     width: 100%;
+    transition: opacity 0.15s ease;
+}
+
+.lightbox-img-and-meta.lightbox-transitioning {
+    opacity: 0;
 }
 
 .lightbox-site-title {

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -103,6 +103,7 @@
     var ruleEl = overlay.querySelector('.lightbox-rule');
     var headerRuleEl = overlay.querySelector('.lightbox-header-rule');
     var thumbLinks = Array.from(document.querySelectorAll('.photo-thumb-link'));
+    var imgAndMeta = overlay.querySelector('.lightbox-img-and-meta');
     var currentIndex = -1;
     var showGen = 0;
 
@@ -119,10 +120,6 @@
         var photo = allPhotos[index];
         var hadSrc = !!img.getAttribute('src');
 
-        titleEl.textContent = photo.title || '';
-        descEl.textContent = photo.description || '';
-        titleEl.style.display = photo.title ? '' : 'none';
-        descEl.style.display = photo.description ? '' : 'none';
         navPrev.style.visibility = index > 0 ? 'visible' : 'hidden';
         navNext.style.visibility = index < allPhotos.length - 1 ? 'visible' : 'hidden';
         if (photo.slug) {
@@ -132,22 +129,26 @@
         var preload = new Image();
         preload.onload = function() {
             if (gen !== showGen) return;
-            function applyImage() {
+            function applyContent() {
                 if (gen !== showGen) return;
                 img.src = photo.src;
                 img.alt = photo.alt || '';
+                titleEl.textContent = photo.title || '';
+                descEl.textContent = photo.description || '';
+                titleEl.style.display = photo.title ? '' : 'none';
+                descEl.style.display = photo.description ? '' : 'none';
                 requestAnimationFrame(function() {
                     if (gen !== showGen) return;
                     syncRuleWidths();
-                    img.classList.remove('lightbox-img-loading');
+                    imgAndMeta.classList.remove('lightbox-transitioning');
                 });
             }
             if (hadSrc) {
-                img.classList.add('lightbox-img-loading');
-                setTimeout(applyImage, 150);
+                imgAndMeta.classList.add('lightbox-transitioning');
+                setTimeout(applyContent, 150);
             } else {
-                img.classList.add('lightbox-img-loading');
-                applyImage();
+                imgAndMeta.classList.add('lightbox-transitioning');
+                applyContent();
             }
         };
         preload.src = photo.src;

--- a/layouts/photography/list.html
+++ b/layouts/photography/list.html
@@ -84,6 +84,7 @@
     var navNext = overlay.querySelector('.lightbox-nav-next');
     var ruleEl = overlay.querySelector('.lightbox-rule');
     var headerRuleEl = overlay.querySelector('.lightbox-header-rule');
+    var imgAndMeta = overlay.querySelector('.lightbox-img-and-meta');
     var currentIndex = -1;
     var showGen = 0;
 
@@ -113,10 +114,6 @@
             }
             shown = Math.max(shown, index + 1);
         }
-        titleEl.textContent = link.dataset.title || '';
-        descEl.textContent = link.dataset.description || '';
-        titleEl.style.display = link.dataset.title ? '' : 'none';
-        descEl.style.display = link.dataset.description ? '' : 'none';
         navPrev.style.visibility = index > 0 ? 'visible' : 'hidden';
         navNext.style.visibility = index < allItems.length - 1 ? 'visible' : 'hidden';
         if (link.dataset.slug) {
@@ -126,22 +123,26 @@
         var preload = new Image();
         preload.onload = function() {
             if (gen !== showGen) return;
-            function applyImage() {
+            function applyContent() {
                 if (gen !== showGen) return;
                 img.src = link.href;
                 img.alt = link.dataset.alt || '';
+                titleEl.textContent = link.dataset.title || '';
+                descEl.textContent = link.dataset.description || '';
+                titleEl.style.display = link.dataset.title ? '' : 'none';
+                descEl.style.display = link.dataset.description ? '' : 'none';
                 requestAnimationFrame(function() {
                     if (gen !== showGen) return;
                     syncRuleWidths();
-                    img.classList.remove('lightbox-img-loading');
+                    imgAndMeta.classList.remove('lightbox-transitioning');
                 });
             }
             if (hadSrc) {
-                img.classList.add('lightbox-img-loading');
-                setTimeout(applyImage, 150);
+                imgAndMeta.classList.add('lightbox-transitioning');
+                setTimeout(applyContent, 150);
             } else {
-                img.classList.add('lightbox-img-loading');
-                applyImage();
+                imgAndMeta.classList.add('lightbox-transitioning');
+                applyContent();
             }
         };
         preload.src = link.href;


### PR DESCRIPTION
## Summary
- When navigating between photos, the entire content area (image + title + rule + description) now fades out together
- All content swaps and layout shifts happen while invisible, then fades back in
- Previously only the image faded, leaving visible jumps in the title/description text below

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [ ] Clicking a thumbnail opens lightbox with smooth fade-in (no delay)
- [ ] Navigating between photos fades entire content area (no visible layout jump)
- [ ] Title, description, and rule update during invisible phase
- [ ] Keyboard navigation (arrow keys) also transitions smoothly
- [ ] Close/escape still works correctly on both pages

Generated with [Claude Code](https://claude.com/claude-code)