### PR TITLE
feat: fix PWA installation and add AI feedback/regenerate

### DIFF
--- a/functions/api/describe-photo.js
+++ b/functions/api/describe-photo.js
@@ -1,15 +1,13 @@
 var ALLOWED_ORIGIN = 'https://mrmatt.io';
 
 var SYSTEM_PROMPT = [
-    'You are writing photo descriptions for Matt Walker\'s personal photography gallery at mrmatt.io.',
-    'Matt is a software engineer in the Baltimore/DC area who is into coffee, cooking with cast iron,',
-    'rowing, snow sports, hiking, homelab tinkering, and general dad-life adventures.',
+    'You are writing photo descriptions for a personal photography gallery.',
     '',
     'For the given photo, respond with ONLY valid JSON (no markdown, no code fences):',
     '{',
     '  "title": "Short title, 2-4 words",',
     '  "alt": "One factual sentence describing what is visible, for screen readers",',
-    '  "description": "1-2 sentences, warm and slightly witty, like a friend commenting on the photo. Connect to Matt\'s interests when relevant. Never generic or stock-photo-sounding."',
+    '  "description": "1-2 natural sentences describing the photo. Match the tone to the subject matter. Don\'t force connections to hobbies or interests unless clearly relevant."',
     '}'
 ].join('\n');
 
@@ -40,11 +38,17 @@ export async function onRequestPost(context) {
         var body = await request.json();
         var imageBase64 = body.image;
         var mediaType = body.media_type || 'image/jpeg';
+        var feedback = body.feedback || '';
 
         if (!imageBase64) {
             return new Response(JSON.stringify({ error: 'Missing image data' }), {
                 status: 400, headers: headers
             });
+        }
+
+        var userText = 'Describe this photo for my gallery.';
+        if (feedback) {
+            userText += ' Additional direction from the photographer: ' + feedback;
         }
 
         var anthropicResponse = await fetch('https://api.anthropic.com/v1/messages', {
@@ -71,7 +75,7 @@ export async function onRequestPost(context) {
                         },
                         {
                             type: 'text',
-                            text: 'Describe this photo for my gallery.'
+                            text: userText
                         }
                     ]
                 }]

--- a/static/upload/index.html
+++ b/static/upload/index.html
@@ -50,6 +50,10 @@
                     <span id="ai-description"></span>
                 </div>
             </div>
+            <div class="ai-feedback">
+                <input type="text" id="ai-feedback" placeholder="e.g. &quot;This is a sunrise over the harbor, keep it simple&quot;">
+                <button id="regenerate-btn" class="btn btn-secondary">Regenerate</button>
+            </div>
         </div>
 
         <div class="field">

--- a/static/upload/manifest.json
+++ b/static/upload/manifest.json
@@ -7,14 +7,15 @@
   "theme_color": "#090909",
   "icons": [
     {
-      "src": "/favicon-192x192.png",
+      "src": "/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/favicon-384x384.png",
+      "src": "/android-chrome-384x384.png",
       "sizes": "384x384",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     }
   ],
   "share_target": {

--- a/static/upload/style.css
+++ b/static/upload/style.css
@@ -180,3 +180,24 @@ h1 {
 .ai-section .status {
     margin-bottom: 0.5rem;
 }
+
+.ai-feedback {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
+}
+
+.ai-feedback input[type="text"] {
+    flex: 1;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid #d0d0d0;
+    border-radius: 4px;
+    font-family: "Roboto Slab", serif;
+    font-size: 0.85rem;
+}
+
+.ai-feedback .btn {
+    white-space: nowrap;
+    font-size: 0.85rem;
+    padding: 0.4rem 0.8rem;
+}

--- a/static/upload/sw.js
+++ b/static/upload/sw.js
@@ -1,8 +1,9 @@
-var CACHE_NAME = 'photo-upload-v1';
+var CACHE_NAME = 'photo-upload-v2';
 var ASSETS = [
     '/upload/',
     '/upload/style.css',
-    '/upload/app.js'
+    '/upload/app.js',
+    '/upload/manifest.json'
 ];
 
 self.addEventListener('install', function(e) {


### PR DESCRIPTION
## Summary
- Fix PWA install on Android by correcting manifest icon paths (`favicon-*.png` → `android-chrome-*.png`) and adding `"purpose": "any maskable"` to the 384x384 icon
- Switch OAuth state storage from `sessionStorage` to `localStorage` so standalone PWA mode can complete the OAuth redirect flow without "invalid state" errors
- Bump service worker cache to v2 and add `manifest.json` to cached assets
- Add feedback text input and "Regenerate" button to the AI description section, allowing the photographer to guide AI output before uploading
- Tone down the AI system prompt — remove forced hobby/interest connections and overly cheesy tone guidance

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [ ] Open `/upload/` in DevTools → Application → Manifest — no icon 404s
- [ ] Upload a photo, verify AI generates title/alt/description
- [ ] Type feedback and hit Regenerate — verify new results reflect the direction
- [ ] On Android Chrome, verify PWA install prompt appears
- [ ] Install PWA, complete OAuth — no "invalid state" error
- [ ] Share a photo from gallery to PWA — verify share target works

🤖 Generated with [Claude Code](https://claude.com/claude-code)