### PR TITLE
fix: enforce branch protection for admins

### DIFF
--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -91,7 +91,7 @@ gh api repos/{owner}/{repo}/branches/main/protection \
     "strict": true,
     "contexts": ["build-and-deploy"]
   },
-  "enforce_admins": false,
+  "enforce_admins": true,
   "required_pull_request_reviews": null,
   "restrictions": null,
   "required_linear_history": true,


### PR DESCRIPTION
## Summary
- Set `enforce_admins: true` in the `/setup` skill so branch protection rules apply to repo admins too
- Prevents accidental direct pushes to `main` bypassing CI

## Test plan
- [x] Verified `enforce_admins` is enabled on GitHub
- [x] `/setup` skill updated to default to `true`

Generated with [Claude Code](https://claude.com/claude-code)