### PR TITLE
feat: restyle upload page and fix AI field regressions

### DIFF
--- a/.specs/015-upload-style-fixes.md
+++ b/.specs/015-upload-style-fixes.md
@@ -1,0 +1,68 @@
+# 015: Upload Page Style Fixes & Regression Fix
+
+**Branch**: `feature/upload-style-fixes`
+**Created**: 2026-02-24
+
+## Summary
+
+Fix regressions in the photo upload PWA where AI-generated title/alt/description aren't displaying, the regenerate button doesn't work (both caused by SW caching stale HTML), and restyle the entire upload page to match the main site's aesthetic.
+
+## Requirements
+
+- Revert AI title, alt text, and description from editable `<input>`/`<textarea>` back to read-only text (`<span>`) — use `.textContent` in JS
+- Keep the feedback `<textarea>` and Regenerate button
+- Fix the submit handler to read from `.textContent` instead of `.value`
+- Restyle upload page to match main site: same heading weight/size, max-width `40em` at `width: 90%`, consistent border colors (#e1e1e1), spacing
+- Clean up the AI section layout: results as label+value pairs, feedback textarea full-width below with Regenerate button
+- Bump service worker cache from v3 to v4
+- Add `?v=4` cache-bust query params to `style.css` and `app.js` script/link tags in `index.html` so the SW can't serve stale files
+
+## Design
+
+### HTML changes (`static/upload/index.html`)
+- Revert AI result fields from `<input>`/`<textarea>` to `<span>` elements:
+  - `<span id="ai-title"></span>` (was `<input type="text" id="ai-title">`)
+  - `<span id="ai-alt"></span>` (was `<input type="text" id="ai-alt">`)
+  - `<span id="ai-description"></span>` (was `<textarea id="ai-description">`)
+- Keep labels as `<span class="ai-label">` (not `<label>` since they're not for inputs)
+- Keep feedback `<textarea id="ai-feedback">` and `<button id="regenerate-btn">`
+- Add cache-bust `?v=4` to style.css and app.js references
+
+### JS changes (`static/upload/app.js`)
+- Change `aiTitle.value`, `aiAlt.value`, `aiDesc.value` → `.textContent` everywhere
+- In `describePhoto`: set `.textContent = ''` to clear, `.textContent = data.title` to populate
+- In submit handler: read `aiTitle.textContent.trim()` etc.
+- In reset after upload: set `.textContent = ''`
+
+### CSS changes (`static/upload/style.css`)
+- Match main site layout: `max-width: 40em; width: 90%` on body (was `max-width: 500px`)
+- Match heading style: `h1 { font-weight: 300; font-size: 2rem; letter-spacing: -0.1rem; }`
+- Use site's border color `#e1e1e1` for section borders and separators
+- AI results section: clean label:value pairs on a subtle background
+- AI field values displayed as text (no input borders/boxes)
+- Feedback area: full-width textarea with Regenerate button right-aligned below
+- Remove input/textarea styles from `.ai-field` (no longer inputs)
+- Match button styles to site conventions
+
+### SW changes (`static/upload/sw.js`)
+- Bump cache `photo-upload-v3` → `photo-upload-v4`
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `static/upload/index.html` | Revert AI fields to spans, cache-bust asset URLs |
+| `static/upload/app.js` | Use .textContent instead of .value for AI fields |
+| `static/upload/style.css` | Restyle to match main site aesthetic |
+| `static/upload/sw.js` | Bump cache to v4 |
+
+## Test Plan
+
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [x] AI title, alt, and description display as text (not editable inputs)
+- [x] AI results populate after photo selection
+- [x] Feedback textarea is full-width, multi-line
+- [ ] Regenerate button works — calls API with feedback, updates results
+- [x] Upload page heading and layout match main site style
+- [x] Service worker cache is v4
+- [ ] Upload succeeds with AI-generated metadata in front matter

--- a/static/upload/app.js
+++ b/static/upload/app.js
@@ -257,7 +257,7 @@
         aiSection.style.display = 'block';
         aiStatus.textContent = feedback ? 'Regenerating with your feedback...' : 'Analyzing photo...';
         aiStatus.style.display = 'block';
-        aiTitle.value = '';
+        aiTitle.textContent = '';
         aiAlt.value = '';
         aiDesc.value = '';
         regenerateBtn.disabled = true;
@@ -281,7 +281,7 @@
             .then(function(data) {
                 if (data.error) throw new Error(data.error);
                 aiStatus.style.display = 'none';
-                aiTitle.value = data.title || '';
+                aiTitle.textContent = data.title || '';
                 aiAlt.value = data.alt || '';
                 aiDesc.value = data.description || '';
                 regenerateBtn.disabled = false;
@@ -363,7 +363,7 @@
         submitBtn.disabled = true;
         showStatus('Uploading photo...', 'info');
 
-        var title = aiTitle.value.trim();
+        var title = aiTitle.textContent.trim();
         var alt = aiAlt.value.trim();
         var description = aiDesc.value.trim();
 
@@ -408,7 +408,7 @@
                         window._sharedPhoto = null;
                         currentPhotoFile = null;
                         aiFeedback.value = '';
-                        aiTitle.value = '';
+                        aiTitle.textContent = '';
                         aiAlt.value = '';
                         aiDesc.value = '';
                     })

--- a/static/upload/index.html
+++ b/static/upload/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@300;400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/upload/style.css">
+    <link rel="stylesheet" href="/upload/style.css?v=5">
 </head>
 <body>
     <h1>Photo Upload</h1>
@@ -17,7 +17,7 @@
     <div id="status" class="status" style="display:none;"></div>
 
     <div id="auth-section" class="auth-section">
-        <p style="margin-bottom: 1rem;">Log in with GitHub to upload photos to the gallery.</p>
+        <p>Log in with GitHub to upload photos to the gallery.</p>
         <button id="login-btn" class="btn btn-primary">Log in with GitHub</button>
     </div>
 
@@ -25,7 +25,7 @@
         <div id="user-info" class="user-info" style="display:none;"></div>
         <button id="logout-btn" class="logout-link" style="display:none;">Log out</button>
 
-        <div class="field" style="margin-top: 1rem;">
+        <div class="field">
             <label for="photo-input">Photo</label>
             <input type="file" id="photo-input" accept="image/jpeg,image/png,image/webp">
         </div>
@@ -38,21 +38,20 @@
             <div id="ai-status" class="status info" style="display:none;"></div>
             <div class="ai-results">
                 <div class="ai-field">
-                    <label class="ai-label" for="ai-title">Title</label>
-                    <input type="text" id="ai-title" placeholder="Short title...">
+                    <span class="ai-label">Title</span>
+                    <span id="ai-title" class="ai-value"></span>
                 </div>
                 <div class="ai-field">
-                    <label class="ai-label" for="ai-alt">Alt text</label>
-                    <input type="text" id="ai-alt" placeholder="Descriptive alt text...">
+                    <span class="ai-label">Alt text</span>
+                    <textarea id="ai-alt" class="ai-value" rows="4" readonly></textarea>
                 </div>
                 <div class="ai-field">
-                    <label class="ai-label" for="ai-description">Description</label>
-                    <textarea id="ai-description" rows="2" placeholder="Photo description..."></textarea>
+                    <span class="ai-label">Description</span>
+                    <textarea id="ai-description" class="ai-value" rows="8" readonly></textarea>
                 </div>
             </div>
             <div class="ai-feedback">
-                <label class="ai-label" for="ai-feedback">Feedback</label>
-                <textarea id="ai-feedback" rows="2" placeholder="e.g. &quot;This is a sunrise over the harbor, keep it simple&quot;"></textarea>
+                <textarea id="ai-feedback" rows="4" placeholder="Provide direction, e.g. &quot;this is a sunrise over the harbor, keep it simple&quot;"></textarea>
                 <button id="regenerate-btn" class="btn btn-secondary">Regenerate</button>
             </div>
         </div>
@@ -62,6 +61,6 @@
         </div>
     </div>
 
-    <script src="/upload/app.js"></script>
+    <script src="/upload/app.js?v=5"></script>
 </body>
 </html>

--- a/static/upload/style.css
+++ b/static/upload/style.css
@@ -9,23 +9,31 @@ body {
     background: #fff;
     color: #090909;
     line-height: 1.6;
-    padding: 2rem 1rem;
-    max-width: 500px;
+    padding: 2rem 0;
+    max-width: 40em;
+    width: 90%;
     margin: 0 auto;
 }
 
 h1 {
     font-weight: 300;
-    font-size: 1.8rem;
-    letter-spacing: -0.05rem;
+    font-size: 2rem;
+    letter-spacing: -0.1rem;
+    line-height: 1.2;
     margin-bottom: 1.5rem;
+}
+
+@media (min-width: 550px) {
+    h1 {
+        font-size: 2.4rem;
+    }
 }
 
 .status {
     padding: 0.75rem 1rem;
     border-radius: 4px;
     margin-bottom: 1.5rem;
-    font-size: 0.9rem;
+    font-size: 0.95rem;
 }
 
 .status.info {
@@ -45,6 +53,10 @@ h1 {
 
 .auth-section {
     margin-bottom: 2rem;
+}
+
+.auth-section p {
+    margin-bottom: 1rem;
 }
 
 .btn {
@@ -91,7 +103,7 @@ h1 {
 }
 
 .field {
-    margin-bottom: 1.25rem;
+    margin-bottom: 1.5rem;
 }
 
 .field label {
@@ -102,22 +114,13 @@ h1 {
     color: #555;
 }
 
-.field input[type="text"] {
-    width: 100%;
-    padding: 0.5rem 0.75rem;
-    border: 1px solid #d0d0d0;
-    border-radius: 4px;
-    font-family: "Roboto Slab", serif;
-    font-size: 0.95rem;
-}
-
 .field input[type="file"] {
     font-family: "Roboto Slab", serif;
     font-size: 0.9rem;
 }
 
 .preview {
-    margin-bottom: 1.25rem;
+    margin-bottom: 1.5rem;
     display: none;
 }
 
@@ -133,14 +136,13 @@ h1 {
 }
 
 .actions {
-    display: flex;
-    gap: 0.75rem;
+    margin-top: 0.5rem;
 }
 
 .user-info {
     font-size: 0.85rem;
     color: #555;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0.25rem;
 }
 
 .logout-link {
@@ -151,70 +153,90 @@ h1 {
     border: none;
     font-family: "Roboto Slab", serif;
     font-size: 0.85rem;
+    margin-bottom: 1.5rem;
+    display: inline-block;
 }
 
 /* AI description section */
 .ai-section {
-    margin-bottom: 1.25rem;
-    padding: 0.75rem 1rem;
-    background: #f5f5f5;
+    margin-bottom: 1.5rem;
+    padding: 1rem;
+    background: #f8f8f8;
+    border: 1px solid #e1e1e1;
     border-radius: 4px;
+}
+
+.ai-section .status {
+    margin-bottom: 0.75rem;
 }
 
 .ai-results {
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.6rem;
 }
 
 .ai-field {
-    font-size: 0.9rem;
-    line-height: 1.4;
     display: flex;
     flex-direction: column;
-    gap: 0.2rem;
-}
-
-.ai-field input[type="text"],
-.ai-field textarea {
-    width: 100%;
-    padding: 0.4rem 0.6rem;
-    border: 1px solid #d0d0d0;
-    border-radius: 4px;
-    font-family: "Roboto Slab", serif;
-    font-size: 0.9rem;
-    resize: vertical;
+    gap: 0.15rem;
 }
 
 .ai-label {
-    font-weight: 700;
     font-size: 0.8rem;
+    font-weight: 700;
     color: #555;
+    text-transform: uppercase;
+    letter-spacing: 0.03rem;
 }
 
-.ai-section .status {
-    margin-bottom: 0.5rem;
+.ai-value {
+    font-size: 0.95rem;
+    line-height: 1.5;
+    color: #090909;
 }
 
+textarea.ai-value {
+    width: 100%;
+    background: transparent;
+    border: none;
+    resize: none;
+    font-family: "Roboto Slab", serif;
+    padding: 0;
+    outline: none;
+}
+
+.ai-value:empty::after {
+    content: "\2014";
+    color: #ccc;
+}
+
+/* Feedback and regenerate */
 .ai-feedback {
-    margin-top: 0.75rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
+    margin-top: 1rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid #e1e1e1;
 }
 
 .ai-feedback textarea {
+    display: block;
     width: 100%;
-    padding: 0.4rem 0.6rem;
+    padding: 0.5rem 0.75rem;
     border: 1px solid #d0d0d0;
     border-radius: 4px;
     font-family: "Roboto Slab", serif;
-    font-size: 0.85rem;
+    font-size: 0.9rem;
+    line-height: 1.5;
     resize: vertical;
+    margin-bottom: 0.5rem;
+}
+
+.ai-feedback textarea:focus {
+    outline: none;
+    border-color: #999;
 }
 
 .ai-feedback .btn {
-    align-self: flex-end;
     font-size: 0.85rem;
     padding: 0.4rem 0.8rem;
 }

--- a/static/upload/sw.js
+++ b/static/upload/sw.js
@@ -1,4 +1,4 @@
-var CACHE_NAME = 'photo-upload-v3';
+var CACHE_NAME = 'photo-upload-v5';
 var ASSETS = [
     '/upload/',
     '/upload/style.css',


### PR DESCRIPTION
## Summary
- Fix regression where AI-generated title/alt/description weren't displaying (caused by SW caching stale HTML with `.value` on `<span>` elements)
- Revert AI fields to read-only display (title as span, alt/description as readonly textareas with 4/8 rows)
- Restyle entire upload page to match main site aesthetic (40em max-width, matching headings, consistent #e1e1e1 borders)
- Bump SW cache to v5 with `?v=5` cache-bust query params to prevent stale files
- Integrate EXIF date extraction feature from main

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [x] AI title, alt, and description display as text (not editable inputs)
- [x] AI results populate after photo selection
- [x] Feedback textarea is full-width, multi-line (4 rows)
- [ ] Regenerate button works — calls API with feedback, updates results
- [x] Upload page heading and layout match main site style
- [x] Service worker cache is v5
- [ ] Upload succeeds with AI-generated metadata in front matter

Generated with [Claude Code](https://claude.com/claude-code)