### PR TITLE
feat: tighten AI field heights on upload page

### DIFF
--- a/.specs/016-upload-tighten-spacing.md
+++ b/.specs/016-upload-tighten-spacing.md
@@ -1,0 +1,40 @@
+# 016: Tighten Upload AI Field Heights
+
+**Branch**: `feature/upload-tighten-spacing`
+**Created**: 2026-02-24
+
+## Summary
+
+Reduce the row count on the read-only alt text and description textareas in the photo upload page. Since these are no longer editable, the large heights (`rows="4"` and `rows="8"`) waste space. Shrink them to fit typical AI output while keeping the feedback textarea at its current size.
+
+## Requirements
+
+- Reduce alt text textarea from `rows="4"` to `rows="2"`
+- Reduce description textarea from `rows="8"` to `rows="3"`
+- Keep feedback textarea at `rows="4"` (unchanged)
+- Bump cache-bust query params to `?v=6` and SW cache to `photo-upload-v6`
+
+## Design
+
+### HTML changes (`static/upload/index.html`)
+- Line 46: `rows="4"` → `rows="2"` on `#ai-alt`
+- Line 50: `rows="8"` → `rows="3"` on `#ai-description`
+- Update `?v=5` → `?v=6` on style.css and app.js references
+
+### SW changes (`static/upload/sw.js`)
+- Bump `photo-upload-v5` → `photo-upload-v6`
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `static/upload/index.html` | Reduce textarea rows, bump cache-bust to v6 |
+| `static/upload/sw.js` | Bump cache to v6 |
+
+## Test Plan
+
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [x] Alt text area is compact (2 rows)
+- [x] Description area is compact (3 rows)
+- [x] Feedback textarea unchanged (4 rows)
+- [x] Service worker cache is v6

--- a/static/upload/index.html
+++ b/static/upload/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@300;400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/upload/style.css?v=5">
+    <link rel="stylesheet" href="/upload/style.css?v=6">
 </head>
 <body>
     <h1>Photo Upload</h1>
@@ -43,11 +43,11 @@
                 </div>
                 <div class="ai-field">
                     <span class="ai-label">Alt text</span>
-                    <textarea id="ai-alt" class="ai-value" rows="4" readonly></textarea>
+                    <textarea id="ai-alt" class="ai-value" rows="2" readonly></textarea>
                 </div>
                 <div class="ai-field">
                     <span class="ai-label">Description</span>
-                    <textarea id="ai-description" class="ai-value" rows="8" readonly></textarea>
+                    <textarea id="ai-description" class="ai-value" rows="3" readonly></textarea>
                 </div>
             </div>
             <div class="ai-feedback">
@@ -61,6 +61,6 @@
         </div>
     </div>
 
-    <script src="/upload/app.js?v=5"></script>
+    <script src="/upload/app.js?v=6"></script>
 </body>
 </html>

--- a/static/upload/sw.js
+++ b/static/upload/sw.js
@@ -1,4 +1,4 @@
-var CACHE_NAME = 'photo-upload-v5';
+var CACHE_NAME = 'photo-upload-v6';
 var ASSETS = [
     '/upload/',
     '/upload/style.css',


### PR DESCRIPTION
## Summary
- Reduce read-only alt text textarea from 4 rows to 2 and description from 8 rows to 3, since they no longer need to be large editable fields
- Keep feedback textarea at 4 rows (unchanged)
- Bump SW cache to v6 with cache-bust query params

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [x] Alt text area is compact (2 rows)
- [x] Description area is compact (3 rows)
- [x] Feedback textarea unchanged (4 rows)
- [x] Service worker cache is v6

Generated with [Claude Code](https://claude.com/claude-code)