### PR TITLE
fix: deploy Cloudflare Functions with --functions-directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,4 +46,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy public --project-name=mrmatt-io --commit-dirty=true
+          command: pages deploy public --project-name=mrmatt-io --functions-directory=functions --commit-dirty=true

--- a/.specs/018-fix-describe-photo-deploy.md
+++ b/.specs/018-fix-describe-photo-deploy.md
@@ -1,0 +1,44 @@
+# 018: Fix Cloudflare Functions Deployment
+
+**Branch**: `feature/fix-describe-photo-deploy`
+**Created**: 2026-02-24
+
+## Summary
+
+The AI photo description endpoint returns HTML (404 page) instead of JSON because the `wrangler pages deploy` command in the GitHub Actions workflow doesn't include the `functions/` directory. Fix by adding `--functions-directory=functions` to the deploy command and improve client-side error handling for non-JSON responses.
+
+## Requirements
+
+- Add `--functions-directory=functions` to the wrangler deploy command so Cloudflare Pages Functions are deployed
+- Add `r.ok` check in the client-side `describePhoto` fetch to catch non-JSON responses gracefully
+- Bump SW cache to v8 and cache-bust to `?v=8`
+
+## Design
+
+### Workflow changes (`.github/workflows/deploy.yml`)
+- Line 49: Add `--functions-directory=functions` to the `pages deploy` command
+
+### JS changes (`static/upload/app.js`)
+- In `describePhoto`, after the fetch, check `r.ok` before calling `r.json()`. If not OK, throw an error with the status code instead of trying to parse HTML as JSON.
+
+### HTML changes (`static/upload/index.html`)
+- Bump cache-bust `?v=7` → `?v=8`
+
+### SW changes (`static/upload/sw.js`)
+- Bump `photo-upload-v7` → `photo-upload-v8`
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `.github/workflows/deploy.yml` | Add --functions-directory=functions to deploy |
+| `static/upload/app.js` | Better error handling for non-JSON responses |
+| `static/upload/index.html` | Bump cache-bust to v8 |
+| `static/upload/sw.js` | Bump cache to v8 |
+
+## Test Plan
+
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [x] Deploy workflow includes `--functions-directory=functions`
+- [ ] AI description endpoint returns JSON (verify after deploy)
+- [x] Non-JSON error responses show meaningful error message

--- a/static/upload/app.js
+++ b/static/upload/app.js
@@ -277,7 +277,10 @@
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(requestBody)
             })
-            .then(function(r) { return r.json(); })
+            .then(function(r) {
+                if (!r.ok) throw new Error('API error: ' + r.status);
+                return r.json();
+            })
             .then(function(data) {
                 if (data.error) throw new Error(data.error);
                 aiStatus.style.display = 'none';

--- a/static/upload/index.html
+++ b/static/upload/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@300;400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/upload/style.css?v=7">
+    <link rel="stylesheet" href="/upload/style.css?v=8">
 </head>
 <body>
     <h1>Photo Upload</h1>
@@ -61,6 +61,6 @@
         </div>
     </div>
 
-    <script src="/upload/app.js?v=7"></script>
+    <script src="/upload/app.js?v=8"></script>
 </body>
 </html>

--- a/static/upload/sw.js
+++ b/static/upload/sw.js
@@ -1,4 +1,4 @@
-var CACHE_NAME = 'photo-upload-v7';
+var CACHE_NAME = 'photo-upload-v8';
 var ASSETS = [
     '/upload/',
     '/upload/style.css',


### PR DESCRIPTION
## Summary
- AI describe-photo endpoint was returning HTML (404 page) instead of JSON because `wrangler pages deploy` wasn't including the `functions/` directory
- Added `--functions-directory=functions` to the deploy command so all Cloudflare Pages Functions are deployed
- Improved client-side error handling to check `r.ok` before parsing JSON, preventing cryptic parse errors

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [x] Deploy workflow includes `--functions-directory=functions`
- [ ] AI description endpoint returns JSON (verify after deploy)
- [x] Non-JSON error responses show meaningful error message

Generated with [Claude Code](https://claude.com/claude-code)