### PR TITLE
fix: build Cloudflare Functions before deploying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,10 +40,18 @@ jobs:
           command: pages project create mrmatt-io --production-branch=main
         continue-on-error: true
 
+      - name: Build Cloudflare Functions
+        if: github.ref == 'refs/heads/main'
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages functions build --outdir=public
+
       - name: Deploy to Cloudflare Pages
         if: github.ref == 'refs/heads/main'
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy public --project-name=mrmatt-io --functions-directory=functions --commit-dirty=true
+          command: pages deploy public --project-name=mrmatt-io --commit-dirty=true


### PR DESCRIPTION
## Summary
- The `--functions-directory` flag doesn't exist in `wrangler pages deploy`
- Split into two steps: `wrangler pages functions build --outdir=public` compiles `functions/` into `_worker.js`, then `pages deploy public` uploads everything
- Fixes the broken deploy from #5289

## Test plan
- [ ] Deploy workflow succeeds (build-and-deploy check passes on main)
- [ ] AI describe-photo endpoint returns JSON after deploy

Generated with [Claude Code](https://claude.com/claude-code)