### PR TITLE
fix: convert images to JPEG before AI description

### DIFF
--- a/static/upload/index.html
+++ b/static/upload/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" href="/favicon.ico">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@300;400;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/upload/style.css?v=8">
+    <link rel="stylesheet" href="/upload/style.css?v=9">
 </head>
 <body>
     <h1>Photo Upload</h1>
@@ -27,7 +27,7 @@
 
         <div class="field">
             <label for="photo-input">Photo</label>
-            <input type="file" id="photo-input" accept="image/jpeg,image/png,image/webp">
+            <input type="file" id="photo-input" accept="image/*">
         </div>
 
         <div id="preview" class="preview">
@@ -61,6 +61,6 @@
         </div>
     </div>
 
-    <script src="/upload/app.js?v=8"></script>
+    <script src="/upload/app.js?v=9"></script>
 </body>
 </html>

--- a/static/upload/sw.js
+++ b/static/upload/sw.js
@@ -1,4 +1,4 @@
-var CACHE_NAME = 'photo-upload-v8';
+var CACHE_NAME = 'photo-upload-v9';
 var ASSETS = [
     '/upload/',
     '/upload/style.css',


### PR DESCRIPTION
## Summary
- Raw/HEIC images from Google Photos caused 502 errors because the Anthropic Vision API only supports JPEG/PNG/GIF/WebP
- Added `toJpegBase64()` that converts any image to JPEG via Canvas (resized to max 1024px) before sending to the API
- Changed file input from specific types to `image/*` since we can now handle any format
- Bumped SW cache to v9

## Test plan
- [ ] JPEG images still get AI descriptions
- [ ] Raw/HEIC images from Google Photos now get AI descriptions instead of 502
- [x] Hugo builds with no errors

Generated with [Claude Code](https://claude.com/claude-code)