### PR TITLE
feat: expand /stack page with photo PWA, AI, and dev workflow

### DIFF
--- a/.specs/019-update-stack-page.md
+++ b/.specs/019-update-stack-page.md
@@ -1,0 +1,49 @@
+# 019: Update Stack Page
+
+**Branch**: `feature/update-stack-page`
+**Created**: 2026-02-24
+
+## Summary
+
+Overhaul the /stack page to showcase the full technical stack behind mrmatt.io, including the photo upload PWA, Claude AI-powered image descriptions, automated GitHub publishing workflow, Cloudflare Functions backend, and spec-driven development workflow with Claude Code.
+
+## Requirements
+
+- Keep the existing items (Hugo, PaperMod, GitHub Actions, Cloudflare Pages, Cloudflare DNS, Web Analytics)
+- Add section for the Photo Upload PWA (vanilla JS, Service Worker, IndexedDB, Android share target, native EXIF parsing)
+- Add section for AI-powered photo descriptions (Claude Haiku 4.5 Vision API, feedback loop, Cloudflare Functions proxy)
+- Add section for automated publishing workflow (GitHub OAuth, REST + GraphQL API, feature branches, auto-merge PRs)
+- Add section for serverless backend (Cloudflare Pages Functions for OAuth and AI proxy)
+- Add section for development workflow (spec-driven development with Claude Code, worktree isolation, /feature + /ship commands)
+- Update design philosophy to reflect the "minimal but smart" approach
+- Maintain the existing tone — concise, list-driven, no bloat
+- No code snippets or deep technical prose — keep it scannable
+
+## Design
+
+Update `content/stack/index.md` with expanded sections. Each section gets an h3 heading with bulleted details underneath. The page should read like a curated technical resume of the site itself — what powers it and why those choices were made.
+
+Structure:
+1. Static Site (Hugo + PaperMod — existing)
+2. Photo Upload (PWA with vanilla JS, Service Worker, share target)
+3. AI Descriptions (Claude Vision API via Cloudflare Functions)
+4. Automated Publishing (GitHub API workflow from mobile to live)
+5. Serverless Backend (Cloudflare Pages Functions)
+6. CI/CD (GitHub Actions — existing, expanded)
+7. Hosting & DNS (Cloudflare Pages + DNS + Analytics — existing, consolidated)
+8. Development (spec-driven with Claude Code)
+9. Design Philosophy (updated)
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `content/stack/index.md` | Rewrite with expanded sections |
+
+## Test Plan
+
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [x] Site renders correctly on localhost (`hugo server -D`)
+- [ ] Stack page displays all new sections with correct formatting
+- [ ] All external links are valid
+- [ ] Page reads well on mobile viewport

--- a/content/stack/index.md
+++ b/content/stack/index.md
@@ -6,25 +6,62 @@ layout: "single"
 
 *Source available on GitHub: [MrMatt57/MrMatt.io](https://github.com/MrMatt57/MrMatt.io)*
 
-### Static Site Generator
+### Static Site
 
-- [Hugo](https://gohugo.io/) (extended) with [PaperMod](https://github.com/adityatelange/hugo-PaperMod) theme
+- [Hugo](https://gohugo.io/) (extended) with [PaperMod](https://github.com/adityatelange/hugo-PaperMod) theme (git submodule)
+- Custom CSS with [Roboto Slab](https://fonts.google.com/specimen/Roboto+Slab) typography
+- No npm, no build tools — Hugo's built-in asset pipeline handles everything
+
+### Photo Upload
+
+- Vanilla JS progressive web app at [`/upload`](/upload) — no frameworks, no dependencies
+- Android share target — share a photo directly from the camera roll to the site
+- Service Worker with network-first caching and IndexedDB for offline queuing
+- Native EXIF parsing from raw JPEG bytes to extract photo dates — no libraries
+- Client-side image conversion and resizing via Canvas API before sending to AI
+
+### AI-Powered Descriptions
+
+- [Anthropic Claude](https://www.anthropic.com/) Haiku 4.5 vision model generates photo titles, alt text, and descriptions from uploaded images
+- Cloudflare Pages Function proxies requests to the Anthropic API, keeping the API key server-side
+- Feedback loop — review the AI output, provide guidance, and regenerate until it's right
+- Structured JSON output parsed directly into Hugo front matter fields
+
+### Automated Publishing
+
+- GitHub OAuth authentication scoped to the repo owner
+- Upload creates a feature branch (`photo/YYYY-MM-DD-slug`), commits the image and Hugo content file, opens a PR, and enables auto-merge — all from the phone
+- GitHub REST API for branches, blobs, trees, and commits; GraphQL API for the auto-merge mutation
+- Photo goes from camera roll to live on the site with no terminal, no laptop
+
+### Serverless Backend
+
+- [Cloudflare Pages Functions](https://developers.cloudflare.com/pages/functions/) (three endpoints)
+- `/api/describe-photo` — Claude Vision proxy with CORS locked to mrmatt.io
+- `/api/oauth-exchange` — GitHub OAuth token exchange
+- `/api/oauth-client-id` — serves the OAuth client ID to the frontend
 
 ### CI/CD
 
-- GitHub Actions — build and deploy on push
+- [GitHub Actions](https://github.com/features/actions) — builds Hugo with submodules, compiles Cloudflare Functions, and deploys on every push to main
+- Concurrency controls cancel in-progress deploys when a new push arrives
+- Branch deploys for PR previews
 
-### Hosting
+### Hosting & DNS
 
 - [Cloudflare Pages](https://pages.cloudflare.com/) (free tier)
-- Cloudflare Web Analytics (no JS tag)
+- Cloudflare DNS
+- Cloudflare Web Analytics — server-side, no JavaScript tag
 
-### DNS
+### Development
 
-- Cloudflare
+- Spec-driven workflow — every feature starts with a numbered spec in `.specs/` before any code is written
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) for interactive development — `/feature` creates a spec + git worktree, `/ship` commits, pushes, opens a PR with auto-merge, and cleans up
+- Git worktree isolation keeps the main checkout clean while features are in progress
 
 ### Design Philosophy
 
 - Minimal and fast — no JS frameworks, no bloat, static HTML/CSS
 - Content-first — the site publishes writing and serves as a professional presence
 - Low maintenance — no comment systems, no dynamic backends
+- Automation where it matters — AI and APIs handle the tedious parts so publishing stays frictionless


### PR DESCRIPTION
## Summary
- Overhaul the /stack page to showcase the full technical stack behind mrmatt.io
- Add sections for Photo Upload PWA, AI-Powered Descriptions, Automated Publishing, Serverless Backend, and Development workflow
- Update existing sections (CI/CD, Hosting, DNS) with more detail
- Add "automation where it matters" to design philosophy

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [x] Site renders correctly on localhost (`hugo server -D`)
- [ ] Stack page displays all new sections with correct formatting
- [ ] All external links are valid
- [ ] Page reads well on mobile viewport

Generated with [Claude Code](https://claude.com/claude-code)