### PR TITLE
feat: add CalVer release versioning to deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       deployments: write
     steps:
       - uses: actions/checkout@v6
@@ -55,3 +55,22 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: pages deploy public --project-name=mrmatt-io --commit-dirty=true
+
+      - name: Create Release
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git fetch --tags
+          DATE=$(date -u +%Y.%m.%d)
+          LAST=$(git tag -l "${DATE}.*" | sort -t. -k4 -n | tail -1)
+          if [ -z "$LAST" ]; then
+            VERSION="${DATE}.1"
+          else
+            N=$(echo "$LAST" | awk -F. '{print $NF}')
+            VERSION="${DATE}.$((N + 1))"
+          fi
+          gh release create "$VERSION" \
+            --generate-notes \
+            --title "$VERSION" \
+            --target "$GITHUB_SHA"

--- a/.specs/020-release-versioning.md
+++ b/.specs/020-release-versioning.md
@@ -1,0 +1,45 @@
+# 020: CalVer Release Versioning
+
+**Branch**: `feature/release-versioning`
+**Created**: 2026-02-24
+
+## Summary
+
+Add calendar-based versioning (CalVer) and GitHub Releases to every production deployment. Each merge to `main` that triggers a deploy will also create a GitHub Release tagged `YYYY.MM.DD.N` where N increments per day. This gives full deployment history with auto-generated release notes in GitHub.
+
+## Requirements
+
+- Every successful deploy to Cloudflare Pages creates a GitHub Release
+- Version format: `YYYY.MM.DD.N` (e.g., `2026.02.24.1`, `2026.02.24.2`)
+- N starts at 1 for the first release of a day and increments for subsequent releases
+- Release includes auto-generated notes from commits/PRs since the last release
+- Only production deploys (pushes to `main`) create releases, not PR builds
+
+## Design
+
+Modify `.github/workflows/deploy.yml` to:
+
+1. **Upgrade permissions**: Change `contents: read` to `contents: write` so the workflow can create tags and releases.
+2. **Add a release step** after the Cloudflare Pages deploy step that:
+   - Fetches all existing tags
+   - Computes today's date in UTC (`YYYY.MM.DD`)
+   - Finds the highest existing tag for today (if any)
+   - Determines the next version (`DATE.1` or `DATE.(N+1)`)
+   - Creates a GitHub Release with `gh release create` which also creates the git tag
+   - Uses `--generate-notes` for automatic release notes from conventional commits
+
+The `gh release create` command handles both tag creation and release creation in one step, targeting the exact commit SHA that was deployed.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `.github/workflows/deploy.yml` | Upgrade `contents` permission to `write`; add "Create Release" step after deploy |
+
+## Test Plan
+
+- [x] Workflow YAML is valid (no syntax errors)
+- [x] Release step only runs on `main` branch pushes (has `if` condition)
+- [x] Version format matches `YYYY.MM.DD.N` pattern
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [x] Site renders correctly on localhost (`hugo server -D`)


### PR DESCRIPTION
## Summary
- Every production deployment now creates a GitHub Release with a CalVer tag (`YYYY.MM.DD.N`)
- Version auto-increments if multiple deploys happen in one day (e.g., `2026.02.24.1` → `2026.02.24.2`)
- Release notes are auto-generated from conventional commits and merged PRs
- Only fires on pushes to `main`, not PR builds

## Test plan
- [x] Workflow YAML is valid (no syntax errors)
- [x] Release step only runs on `main` branch pushes (has `if` condition)
- [x] Version format matches `YYYY.MM.DD.N` pattern
- [x] Hugo builds with no errors (`hugo --minify`)
- [x] Site renders correctly on localhost (`hugo server -D`)

Generated with [Claude Code](https://claude.com/claude-code)