### PR TITLE
feat: reorder Built With sections in README and stack page

### DIFF
--- a/.specs/021-reorder-built-with.md
+++ b/.specs/021-reorder-built-with.md
@@ -1,0 +1,50 @@
+# 021: Reorder Built With Sections
+
+**Branch**: `feature/reorder-built-with`
+**Created**: 2026-02-24
+
+## Summary
+
+Reorder the "Built With" sections in both `README.md` and the `/stack` page (`content/stack/index.md`) to lead with the core site and development workflow, then infrastructure, then the photo pipeline features. This puts the most broadly impressive tech (spec-driven AI dev workflow, serverless, CI/CD) before the domain-specific features (photo PWA, AI descriptions).
+
+## Requirements
+
+- Reorder README.md "Built With" section to this order:
+  1. Static Site
+  2. Spec-Driven Workflow (renamed from "Development")
+  3. Serverless Backend
+  4. CI/CD
+  5. Automated Publishing
+  6. Photo Upload PWA
+  7. AI-Powered Descriptions
+- Reorder stack page sections to match:
+  1. Static Site
+  2. Development (spec-driven workflow)
+  3. Serverless Backend
+  4. CI/CD
+  5. Hosting & DNS
+  6. Automated Publishing
+  7. Photo Upload
+  8. AI-Powered Descriptions
+  9. Design Philosophy
+- Content of each section stays the same — only the order changes
+- In the README, rename "Development" to "Spec-Driven Workflow" for the bold label (content stays the same)
+
+## Design
+
+Pure reorder of existing content blocks. No content changes, no new sections. Just cut-and-paste the blocks into the new order in both files.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `README.md` | Reorder "Built With" items and rename "Development" to "Spec-Driven Workflow" |
+| `content/stack/index.md` | Reorder sections to match new priority order |
+
+## Test Plan
+
+- [x] README "Built With" sections are in the correct new order
+- [x] Stack page sections are in the correct new order
+- [x] No content was lost or changed — only ordering
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [x] Site renders correctly on localhost (`hugo server -D`)

--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ Personal website of **Matt Walker** — software engineer, data & AI practitione
 
 **Static Site** — [Hugo](https://gohugo.io/) extended with [PaperMod](https://github.com/adityatelange/hugo-PaperMod) theme. No npm, no build tools, no JS frameworks — just Hugo's built-in asset pipeline and custom CSS.
 
-**Photo Upload PWA** — A vanilla JavaScript progressive web app at [`/upload`](https://mrmatt.io/upload/) that works as an Android share target. Snap a photo, share it to the site, and it's published — with offline queuing, EXIF date parsing, and client-side image processing. No libraries, no dependencies.
-
-**AI-Powered Descriptions** — Uploaded photos are automatically described by [Claude](https://www.anthropic.com/) Haiku vision model — generating titles, alt text, and personalized descriptions. Review the AI output, tweak it, regenerate, and publish.
+**Spec-Driven Workflow** — Every feature starts with a numbered spec in `.specs/`, gets built in an isolated git worktree, and ships via automated PR with auto-merge — powered by [Claude Code](https://docs.anthropic.com/en/docs/claude-code).
 
 **Serverless Backend** — Three [Cloudflare Pages Functions](https://developers.cloudflare.com/pages/functions/) handle Claude Vision proxying, GitHub OAuth token exchange, and client configuration — all server-side with CORS locked down.
 
-**Automated Publishing** — Photos go from camera roll to live on the site with zero terminal interaction. The PWA creates a feature branch, commits the image and Hugo content file, opens a PR with auto-merge, and GitHub Actions deploys it.
-
 **CI/CD** — [GitHub Actions](https://github.com/features/actions) builds Hugo, compiles Cloudflare Functions, and deploys on every push to `main`. Concurrency controls cancel in-progress deploys when a new push arrives.
 
-**Development** — Spec-driven workflow powered by [Claude Code](https://docs.anthropic.com/en/docs/claude-code). Every feature starts with a numbered spec in `.specs/`, gets built in an isolated git worktree, and ships via automated PR with auto-merge.
+**Automated Publishing** — Photos go from camera roll to live on the site with zero terminal interaction. The PWA creates a feature branch, commits the image and Hugo content file, opens a PR with auto-merge, and GitHub Actions deploys it.
+
+**Photo Upload PWA** — A vanilla JavaScript progressive web app at [`/upload`](https://mrmatt.io/upload/) that works as an Android share target. Snap a photo, share it to the site, and it's published — with offline queuing, EXIF date parsing, and client-side image processing. No libraries, no dependencies.
+
+**AI-Powered Descriptions** — Uploaded photos are automatically described by [Claude](https://www.anthropic.com/) Haiku vision model — generating titles, alt text, and personalized descriptions. Review the AI output, tweak it, regenerate, and publish.
 
 See the full stack breakdown at **[mrmatt.io/stack](https://mrmatt.io/stack)**
 

--- a/content/stack/index.md
+++ b/content/stack/index.md
@@ -12,27 +12,11 @@ layout: "single"
 - Custom CSS with [Roboto Slab](https://fonts.google.com/specimen/Roboto+Slab) typography
 - No npm, no build tools — Hugo's built-in asset pipeline handles everything
 
-### Photo Upload
+### Development
 
-- Vanilla JS progressive web app at [`/upload`](/upload) — no frameworks, no dependencies
-- Android share target — share a photo directly from the camera roll to the site
-- Service Worker with network-first caching and IndexedDB for offline queuing
-- Native EXIF parsing from raw JPEG bytes to extract photo dates — no libraries
-- Client-side image conversion and resizing via Canvas API before sending to AI
-
-### AI-Powered Descriptions
-
-- [Anthropic Claude](https://www.anthropic.com/) Haiku 4.5 vision model generates photo titles, alt text, and descriptions from uploaded images
-- Cloudflare Pages Function proxies requests to the Anthropic API, keeping the API key server-side
-- Feedback loop — review the AI output, provide guidance, and regenerate until it's right
-- Structured JSON output parsed directly into Hugo front matter fields
-
-### Automated Publishing
-
-- GitHub OAuth authentication scoped to the repo owner
-- Upload creates a feature branch (`photo/YYYY-MM-DD-slug`), commits the image and Hugo content file, opens a PR, and enables auto-merge — all from the phone
-- GitHub REST API for branches, blobs, trees, and commits; GraphQL API for the auto-merge mutation
-- Photo goes from camera roll to live on the site with no terminal, no laptop
+- Spec-driven workflow — every feature starts with a numbered spec in `.specs/` before any code is written
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) for interactive development — `/feature` creates a spec + git worktree, `/ship` commits, pushes, opens a PR with auto-merge, and cleans up
+- Git worktree isolation keeps the main checkout clean while features are in progress
 
 ### Serverless Backend
 
@@ -53,11 +37,27 @@ layout: "single"
 - Cloudflare DNS
 - Cloudflare Web Analytics — server-side, no JavaScript tag
 
-### Development
+### Automated Publishing
 
-- Spec-driven workflow — every feature starts with a numbered spec in `.specs/` before any code is written
-- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) for interactive development — `/feature` creates a spec + git worktree, `/ship` commits, pushes, opens a PR with auto-merge, and cleans up
-- Git worktree isolation keeps the main checkout clean while features are in progress
+- GitHub OAuth authentication scoped to the repo owner
+- Upload creates a feature branch (`photo/YYYY-MM-DD-slug`), commits the image and Hugo content file, opens a PR, and enables auto-merge — all from the phone
+- GitHub REST API for branches, blobs, trees, and commits; GraphQL API for the auto-merge mutation
+- Photo goes from camera roll to live on the site with no terminal, no laptop
+
+### Photo Upload
+
+- Vanilla JS progressive web app at [`/upload`](/upload) — no frameworks, no dependencies
+- Android share target — share a photo directly from the camera roll to the site
+- Service Worker with network-first caching and IndexedDB for offline queuing
+- Native EXIF parsing from raw JPEG bytes to extract photo dates — no libraries
+- Client-side image conversion and resizing via Canvas API before sending to AI
+
+### AI-Powered Descriptions
+
+- [Anthropic Claude](https://www.anthropic.com/) Haiku 4.5 vision model generates photo titles, alt text, and descriptions from uploaded images
+- Cloudflare Pages Function proxies requests to the Anthropic API, keeping the API key server-side
+- Feedback loop — review the AI output, provide guidance, and regenerate until it's right
+- Structured JSON output parsed directly into Hugo front matter fields
 
 ### Design Philosophy
 


### PR DESCRIPTION
## Summary
- Reorder README "Built With" and `/stack` page sections to lead with core site tech and development workflow, then infrastructure, then photo pipeline features
- New order: Static Site, Spec-Driven Workflow, Serverless Backend, CI/CD, Automated Publishing, Photo Upload PWA, AI-Powered Descriptions
- Rename "Development" to "Spec-Driven Workflow" in README for clarity
- Pure reorder — no content changes

## Test plan
- [x] README "Built With" sections are in the correct new order
- [x] Stack page sections are in the correct new order
- [x] No content was lost or changed — only ordering
- [x] Hugo builds with no errors (`hugo --minify`)
- [x] Site renders correctly on localhost (`hugo server -D`)

Generated with [Claude Code](https://claude.com/claude-code)