### PR TITLE
fix: add paragraph spacing to Design Philosophy in README

### DIFF
--- a/.specs/023-philosophy-formatting.md
+++ b/.specs/023-philosophy-formatting.md
@@ -1,0 +1,29 @@
+# 023: Design Philosophy Formatting
+
+**Branch**: `feature/philosophy-formatting`
+**Created**: 2026-02-24
+
+## Summary
+
+Add blank lines between each bold item in the README's Design Philosophy section so they render as separate paragraphs, matching the Built With section's formatting.
+
+## Requirements
+
+- Add a blank line between each `**Bold label**` line in the Design Philosophy section of README.md
+- No content changes — formatting only
+
+## Design
+
+Currently all 8 items are on consecutive lines (no blank line separator), causing them to render as a single dense paragraph in GitHub markdown. Add a blank line between each item so each renders as its own paragraph, matching how Built With items are formatted.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `README.md` | Add blank lines between Design Philosophy items |
+
+## Test Plan
+
+- [x] Each Design Philosophy item is separated by a blank line
+- [x] Formatting matches Built With section style
+- [x] Hugo builds with no errors (`hugo --minify`)

--- a/README.md
+++ b/README.md
@@ -24,12 +24,19 @@ Personal website of **Matt Walker** — software engineer, data & AI practitione
 ## Design Philosophy
 
 **Minimal and fast** — no JS frameworks, no bloat, static HTML/CSS.
+
 **Content-first** — the site publishes writing and serves as a professional presence.
+
 **Zero dependencies** — vanilla JS, no npm, no external libraries anywhere.
+
 **Own your stack** — static files you control, no platform lock-in.
+
 **Low maintenance** — no comment systems, no dynamic backends.
+
 **AI as a collaborator** — Claude generates, the human reviews and refines.
+
 **Spec-driven development** — plan before you build, every feature documented.
+
 **Automation where it matters** — AI and APIs handle the tedious parts so publishing stays frictionless.
 
 ## Built With


### PR DESCRIPTION
## Summary
- Add blank lines between each bold item in the Design Philosophy section so they render as separate paragraphs
- Matches the formatting style used in the Built With section
- No content changes — formatting only

## Test plan
- [x] Each Design Philosophy item is separated by a blank line
- [x] Formatting matches Built With section style
- [x] Hugo builds with no errors (`hugo --minify`)

Generated with [Claude Code](https://claude.com/claude-code)