### PR TITLE
feat: add Mozilla Observatory A+ badge to README

### DIFF
--- a/.specs/028-observatory-badge.md
+++ b/.specs/028-observatory-badge.md
@@ -1,0 +1,24 @@
+# 028: Observatory A+ Badge in README
+
+**Branch**: `feature/observatory-badge`
+**Created**: 2026-03-02
+
+## Summary
+
+Add a Mozilla Observatory A+ badge to the README badge row, showcasing the site's security score.
+
+## Requirements
+
+- Add Observatory badge next to existing security-related badges (before Dependabot)
+- Link to the Observatory analysis page for mrmatt.io
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `README.md` | Add Observatory A+ badge to badge row |
+
+## Test Plan
+
+- [x] Badge markdown is valid shields.io format
+- [x] Link points to correct Observatory analysis URL

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Cloudflare Pages](https://img.shields.io/badge/Cloudflare%20Pages-Deployed-f38020?logo=cloudflarepages&logoColor=white&style=flat)](https://pages.cloudflare.com/)
 [![AI Powered](https://img.shields.io/badge/AI%20Powered-Claude-d97706?logo=anthropic&logoColor=white&style=flat)](https://www.anthropic.com/)
 [![PWA](https://img.shields.io/badge/PWA-Enabled-5A0FC8?logo=pwa&logoColor=white&style=flat)](https://mrmatt.io/upload/)
+[![Mozilla Observatory](https://img.shields.io/badge/Observatory-A+-brightgreen?logo=mozilla&logoColor=white&style=flat)](https://developer.mozilla.org/en-US/observatory/analyze?host=mrmatt.io)
 [![Dependabot](https://img.shields.io/badge/Dependabot-Enabled-025E8C?logo=dependabot&logoColor=white&style=flat)](https://github.com/MrMatt57/MrMatt.io/blob/main/.github/dependabot.yml)
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-lightgrey?style=flat)](https://creativecommons.org/licenses/by/4.0/)
 [![GitHub last commit](https://img.shields.io/github/last-commit/MrMatt57/MrMatt.io?style=flat)](https://github.com/MrMatt57/MrMatt.io/commits/main)


### PR DESCRIPTION
## Summary
- Add Mozilla Observatory A+ shield badge to README badge row
- Links to the Observatory analysis page for mrmatt.io

## Test plan
- [x] Badge markdown is valid shields.io format
- [x] Link points to correct Observatory analysis URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)