### PR TITLE
feat: add preconnect hints for Google Fonts

### DIFF
--- a/.specs/030-font-preconnect.md
+++ b/.specs/030-font-preconnect.md
@@ -1,0 +1,23 @@
+# Spec 030: Font Preconnect Hints
+
+## Summary
+
+Add `<link rel="preconnect">` hints for Google Fonts domains to speed up font loading by ~100-300ms. The site uses Roboto Slab loaded via `@import` in CSS, which means the browser must first download the CSS, parse it, find the `@import`, then start the font connection. Preconnect hints let the browser establish the connection earlier, in parallel with CSS loading.
+
+## Implementation
+
+- Create `layouts/partials/extend_head.html` (PaperMod override hook) with preconnect links for:
+  - `https://fonts.googleapis.com` (serves the CSS)
+  - `https://fonts.gstatic.com` with `crossorigin` attribute (serves the font files)
+
+## Files Changed
+
+- `layouts/partials/extend_head.html` (new) — preconnect link elements
+- `.specs/030-font-preconnect.md` (new) — this spec
+
+## Test Plan
+
+- [x] `hugo --minify` builds without errors
+- [x] `public/index.html` contains `<link rel="preconnect" href="https://fonts.googleapis.com">`
+- [x] `public/index.html` contains `<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>`
+- [x] Preconnect links appear in `<head>` section of built HTML

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,0 +1,3 @@
+{{- /* Preconnect to Google Fonts for faster font loading (~100-300ms savings) */ -}}
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary

- Add `<link rel="preconnect">` hints for `fonts.googleapis.com` and `fonts.gstatic.com` to speed up Google Fonts loading by ~100-300ms
- Uses PaperMod's `extend_head.html` partial hook to inject links into `<head>` on every page
- Addresses the font loading chain: currently the browser must download CSS, parse it, discover the `@import`, then connect to Google Fonts -- preconnect lets it start the connection earlier

## Test plan

- [x] `hugo --minify` builds without errors
- [x] `public/index.html` contains both preconnect link tags
- [x] Links appear in `<head>` section of built HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)