### PR TITLE
feat: add site meta description and Open Graph image

### DIFF
--- a/.specs/029-site-meta.md
+++ b/.specs/029-site-meta.md
@@ -1,0 +1,30 @@
+# 029 — Site Meta Description & Open Graph Image
+
+## Problem
+
+The homepage `<meta name="description">` tag is empty and there is no `og:image` tag.
+This means social sharing previews (Twitter/X, LinkedIn, Slack, iMessage, etc.) show
+blank cards with no description or image.
+
+## Solution
+
+Add two params to `hugo.toml` under `[params]`:
+
+1. **`description`** — PaperMod's `head.html` renders `site.Params.description` into
+   `<meta name="description">` for the homepage, and `opengraph.html` uses it for
+   `og:description` as a fallback.
+2. **`images`** — PaperMod's `_funcs/get-page-images.html` uses `site.Params.images`
+   as the default OG image when a page has no cover image or `images` front matter.
+   The existing file `static/images/MattWalker-avatar.png` will be referenced.
+
+## Changes
+
+- `hugo.toml`: Add `description` and `images` to `[params]`
+
+## Test Plan
+
+- [x] `hugo --minify` builds without errors
+- [x] `public/index.html` contains `<meta name="description" content="Personal site...`
+- [x] `public/index.html` contains `<meta property="og:description" content="Personal site...`
+- [x] `public/index.html` contains `<meta property="og:image" content="https://mrmatt.io/images/MattWalker-avatar.png">`
+- [x] Avatar file exists at `static/images/MattWalker-avatar.png`

--- a/hugo.toml
+++ b/hugo.toml
@@ -8,6 +8,8 @@ enableRobotsTXT = true
 
 [params]
   env = "production"
+  description = "Personal site of Matt Walker — software engineer, photographer, and hobbyist in the Baltimore/DC area."
+  images = ["/images/MattWalker-avatar.png"]
   defaultTheme = "auto"
   mainSections = ["posts"]
   ShowReadingTime = true


### PR DESCRIPTION
## Summary
- Add `description` param to `[params]` in `hugo.toml` so the homepage `<meta name="description">` and `og:description` tags are populated
- Add `images` param to `[params]` in `hugo.toml` pointing to `/images/MattWalker-avatar.png` so `og:image` and `twitter:image` tags render the avatar
- Social sharing previews (Twitter/X, LinkedIn, Slack, iMessage) will now show a description and image instead of blank cards

## Test plan
- [x] `hugo --minify` builds without errors
- [x] `public/index.html` contains `<meta name="description" content="Personal site...`
- [x] `public/index.html` contains `<meta property="og:description" content="Personal site...`
- [x] `public/index.html` contains `<meta property="og:image" content="https://mrmatt.io/images/MattWalker-avatar.png">`
- [x] Avatar file exists at `static/images/MattWalker-avatar.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)