### PR TITLE
feat: add long-lived cache headers for static assets

### DIFF
--- a/.specs/032-image-cache-ttl.md
+++ b/.specs/032-image-cache-ttl.md
@@ -1,0 +1,30 @@
+# 032: Image Cache TTL Headers
+
+**Branch**: `feature/image-cache-ttl`
+**Created**: 2026-03-02
+
+## Summary
+
+Photography images are served with `Cache-Control: public, max-age=14400` (4 hours) via Cloudflare's default. These are immutable content that should be cached much longer. Add path-specific cache headers for photography assets and other static resources.
+
+## Requirements
+
+- Add `Cache-Control: public, max-age=31536000, immutable` for photography photo.jpg files
+- Add long-lived cache headers for static image assets (favicons, legacy blog images)
+- Do NOT modify the existing `/*` security headers block or CSP header
+- Use Cloudflare Pages `_headers` file path-pattern syntax
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `static/_headers` | Add path-specific cache rules for photography and static assets |
+
+## Test Plan
+
+- [x] Existing `/*` security header block is unchanged
+- [x] CSP header SHA-256 hashes are untouched
+- [x] Photography images get 1-year immutable cache
+- [x] Favicon files get 1-year immutable cache
+- [x] Legacy blog images get 1-year immutable cache
+- [x] Hugo build succeeds and `public/_headers` contains new rules

--- a/static/_headers
+++ b/static/_headers
@@ -5,3 +5,25 @@
   Permissions-Policy: camera=(), microphone=(), geolocation=()
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
   Content-Security-Policy: default-src 'none'; script-src 'self' 'sha256-BpEdBCM/4BJbN8LWEqCQKlp9VGzetdD0UbdMayNyD28=' 'sha256-zTSXYZ/r74pY7Te+wyYtgDRsO/hpzo1oFZH8wmJQwSA=' 'sha256-/cFFbEHjTjpj7DLefsC+h1yhrxRRebLCB86XtBuCtvw=' 'sha256-X5avg43RTxt2cSum+E3xICbowEMaOBxeBiNh05CXDTY=' 'sha256-UBD9lfFHKxagKGHh9S8B2hytN1cmDsFK1Tl1uedsZ0Q=' 'sha256-eyUVosQAviXm2qeOTG819D1n0kSst2gY8VmfgVsZlag=' 'sha256-lJ4Z01cy/ffXcLzmOw9Sf5Og7DR0EmvGxFFQE026yaA=' 'sha256-fV5Y8BV/LzUvEaK+t8H6/4l30sT2JRqPhG8voRYZeVw='; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://i.ytimg.com; connect-src 'self' https://api.github.com; frame-src https://www.youtube.com https://www.youtube-nocookie.com https://maps.google.com; frame-ancestors 'none'; worker-src 'self'; manifest-src 'self'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests
+
+# Photography images — immutable content, cache for 1 year
+/photography/*/photo.jpg
+  Cache-Control: public, max-age=31536000, immutable
+
+# Favicons and app icons — rarely change, cache for 1 year
+/favicon.ico
+  Cache-Control: public, max-age=31536000, immutable
+/favicon-*.png
+  Cache-Control: public, max-age=31536000, immutable
+/apple-touch-icon.png
+  Cache-Control: public, max-age=31536000, immutable
+/android-chrome-*.png
+  Cache-Control: public, max-age=31536000, immutable
+/safari-pinned-tab.svg
+  Cache-Control: public, max-age=31536000, immutable
+
+# Legacy blog images — static content, cache for 1 year
+/img/*
+  Cache-Control: public, max-age=31536000, immutable
+/images/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary

- Add `Cache-Control: public, max-age=31536000, immutable` (1 year) for photography images (`/photography/*/photo.jpg`)
- Add 1-year immutable cache for favicons and app icons (`favicon.ico`, `favicon-*.png`, `apple-touch-icon.png`, `android-chrome-*.png`, `safari-pinned-tab.svg`)
- Add 1-year immutable cache for legacy blog images (`/img/*`, `/images/*`)
- Existing `/*` security headers block and CSP SHA-256 hashes are untouched

## Test plan

- [x] Existing `/*` security header block is unchanged
- [x] CSP header SHA-256 hashes are untouched
- [x] Photography images get 1-year immutable cache
- [x] Favicon files get 1-year immutable cache
- [x] Legacy blog images get 1-year immutable cache
- [x] Hugo build succeeds and `public/_headers` contains new rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)