### PR TITLE
fix: add alt text to lightbox placeholder images

### DIFF
--- a/.specs/033-missing-alt-text.md
+++ b/.specs/033-missing-alt-text.md
@@ -1,0 +1,34 @@
+# 033 — Fix Missing Alt Attribute on Homepage Lightbox Image
+
+## Problem
+
+The homepage has 9 `<img>` tags, but only 8 have meaningful `alt` text. The
+lightbox placeholder image (`<img class="lightbox-img" src="" alt="" />`) has an
+empty `alt` attribute. After Hugo's `--minify` pass, this renders as a bare
+`alt` attribute without `=`, which accessibility scanners flag as missing alt
+text.
+
+The same issue exists in `layouts/photography/list.html`.
+
+## Solution
+
+Replace the empty `alt=""` with a descriptive placeholder `alt="Photo"` on the
+lightbox `<img>` in both:
+- `layouts/index.html`
+- `layouts/photography/list.html`
+
+The JavaScript lightbox code already sets `img.alt = photo.alt || ''`
+dynamically when a photo is selected, so this placeholder is only visible to
+screen readers before a photo loads.
+
+## Files Changed
+
+- `layouts/index.html` — line 75: `alt=""` -> `alt="Photo"`
+- `layouts/photography/list.html` — line 29: `alt=""` -> `alt="Photo"`
+
+## Test Plan
+
+- [x] `hugo --minify` builds without errors
+- [x] All `<img>` tags in `public/index.html` have `alt=` with a value
+- [x] All `<img>` tags in `public/photography/index.html` have `alt=` with a value
+- [x] Lightbox JS still overrides alt text when a photo is opened

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -72,7 +72,7 @@
         </div>
         <div class="lightbox-img-and-meta">
             <div class="lightbox-img-wrap">
-                <img class="lightbox-img" src="" alt="" />
+                <img class="lightbox-img" src="" alt="Photo" />
                 <div class="lightbox-nav lightbox-nav-prev" aria-label="Previous photo">&#8249;</div>
                 <div class="lightbox-nav lightbox-nav-next" aria-label="Next photo">&#8250;</div>
             </div>

--- a/layouts/photography/list.html
+++ b/layouts/photography/list.html
@@ -26,7 +26,7 @@
         </div>
         <div class="lightbox-img-and-meta">
             <div class="lightbox-img-wrap">
-                <img class="lightbox-img" src="" alt="" />
+                <img class="lightbox-img" src="" alt="Photo" />
                 <div class="lightbox-nav lightbox-nav-prev" aria-label="Previous photo">&#8249;</div>
                 <div class="lightbox-nav lightbox-nav-next" aria-label="Next photo">&#8250;</div>
             </div>


### PR DESCRIPTION
## Summary
- The lightbox `<img>` on the homepage and photography page had `alt=""` which Hugo's minifier stripped to a bare `alt` attribute (no value), flagged by accessibility scanners as missing alt text
- Changed `alt=""` to `alt="Photo"` in both `layouts/index.html` and `layouts/photography/list.html`
- The JS lightbox code already overrides alt text dynamically when a photo is selected, so this placeholder only affects the initial hidden state

## Test plan
- [x] `hugo --minify` builds without errors
- [x] All `<img>` tags in `public/index.html` now have `alt=` with a value
- [x] All `<img>` tags in `public/photography/index.html` now have `alt=` with a value
- [x] Lightbox JS still sets photo-specific alt text when opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)