### PR TITLE
feat: enhance RSS feed with full content and author info

### DIFF
--- a/.specs/034-rss-enhancement.md
+++ b/.specs/034-rss-enhancement.md
@@ -1,0 +1,37 @@
+# Spec 034: RSS Feed Enhancement
+
+## Goal
+
+Improve the site's RSS feed with better metadata — author info, a meaningful site description, full post content for feed readers, and proper channel-level metadata.
+
+## Background
+
+Hugo's embedded RSS template has limitations:
+- Channel `<description>` is auto-generated as "Recent content on {title}" — not customizable via config
+- No `<content:encoded>` element — items only include `.Summary` in `<description>`
+- Author info requires `params.author.email` to render `<managingEditor>` and per-item `<author>`
+
+A custom RSS template is needed to address these issues.
+
+## Changes
+
+### 1. Custom RSS template (`layouts/_default/rss.xml`)
+
+Based on Hugo's embedded template with the following enhancements:
+- Channel `<description>` uses `site.Params.description` when available
+- Adds `<content:encoded>` with full `.Content` for each item
+- Includes `<managingEditor>` with author name even without email
+- Adds `xmlns:content` namespace declaration for `content:encoded`
+
+### 2. Config updates (`hugo.toml`)
+
+- Add `description` to `[params]` for the site description used in RSS channel
+
+## Test Plan
+
+- [x] `hugo --minify` builds without errors
+- [x] `public/index.xml` channel `<description>` contains the custom site description
+- [x] `public/index.xml` channel has `<managingEditor>` with author name
+- [x] `public/index.xml` items include `<content:encoded>` with full post content
+- [x] `public/index.xml` channel has `<language>en-us</language>`
+- [x] RSS feed is valid XML

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,70 @@
+{{- /* Custom RSS template — based on Hugo's embedded template with enhancements:
+     - Channel <description> uses site.Params.description
+     - <content:encoded> includes full post content for feed readers
+     - <managingEditor> renders author name even without email
+*/ -}}
+{{- $authorEmail := "" }}
+{{- $authorName := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .email }}
+      {{- $authorEmail = . }}
+    {{- end }}
+    {{- with .name }}
+      {{- $authorName = . }}
+    {{- end }}
+  {{- else }}
+    {{- $authorName = . }}
+  {{- end }}
+{{- end }}
+
+{{- $pctx := . }}
+{{- if .IsHome }}{{ $pctx = .Site }}{{ end }}
+{{- $pages := slice }}
+{{- if or $.IsHome $.IsSection }}
+{{- $pages = $pctx.RegularPages }}
+{{- else }}
+{{- $pages = $pctx.Pages }}
+{{- end }}
+{{- $limit := .Site.Config.Services.RSS.Limit }}
+{{- if ge $limit 1 }}
+{{- $pages = $pages | first $limit }}
+{{- end }}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+  <channel>
+    <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>{{ if and .IsHome site.Params.description }}{{ site.Params.description }}{{ else }}Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}{{ end }}</description>
+    <generator>Hugo</generator>
+    <language>{{ site.Language.LanguageCode }}</language>
+    {{- with $authorEmail }}
+    <managingEditor>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>
+    {{- else }}{{ with $authorName }}
+    <managingEditor>{{ . }}</managingEditor>
+    {{- end }}{{ end }}
+    {{- with $authorEmail }}
+    <webMaster>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</webMaster>
+    {{- end }}
+    {{- with .Site.Copyright }}
+    <copyright>{{ . }}</copyright>
+    {{- end }}
+    {{- if not .Date.IsZero }}
+    <lastBuildDate>{{ (index $pages.ByLastmod.Reverse 0).Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+    {{- end }}
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range $pages }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Summary | transform.XMLEscape | safeHTML }}</description>
+      <content:encoded>{{ .Content | transform.XMLEscape | safeHTML }}</content:encoded>
+    </item>
+    {{- end }}
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary
- Add custom RSS template (`layouts/_default/rss.xml`) that overrides Hugo's embedded template
- Include `<content:encoded>` with full post content so feed readers show complete articles instead of summaries
- Add `<managingEditor>` with author name from `params.author.name`
- Use `site.Params.description` for the home feed's channel `<description>` (falls back to Hugo default for section feeds)

## Test plan
- [x] `hugo --minify` builds without errors
- [x] `public/index.xml` channel `<description>` contains the site description
- [x] `public/index.xml` channel has `<managingEditor>` with author name
- [x] `public/index.xml` items include `<content:encoded>` with full post content (91/91 items verified)
- [x] `public/index.xml` channel has `<language>en-us</language>`
- [x] RSS feed is valid XML

🤖 Generated with [Claude Code](https://claude.com/claude-code)