### PR TITLE
feat: add full resolution download link to gallery lightbox

### DIFF
--- a/.specs/040-gallery-fullsize-link.md
+++ b/.specs/040-gallery-fullsize-link.md
@@ -1,0 +1,75 @@
+# 040: Gallery Full-Size Image Link
+
+**Branch**: `feature/gallery-fullsize-link`
+**Created**: 2026-03-03
+
+## Summary
+
+Add a magnifying glass (🔍+) icon to the photography lightbox view, positioned on the same row as the title but right-aligned within the image width. Clicking it opens the original full-resolution image in a new browser tab. This feature only appears in the lightbox on the photography gallery page — not on the homepage photo strip or in the thumbnail grid.
+
+## Requirements
+
+- Add a magnifying glass + icon to the lightbox title row
+- Icon appears to the right of the title, within the image width boundary
+- Title shifts to left-aligned (currently centered) to accommodate the icon
+- Clicking the icon opens the original full-resolution JPG in a new browser tab
+- Icon has a tooltip explaining its purpose (e.g., "View full-size image")
+- Icon styling matches the gallery's dark aesthetic (white, subtle opacity)
+- Does NOT appear on the homepage photo strip lightbox
+- Does NOT appear in the thumbnail grid view
+- Accessible: proper aria-label on the button
+
+## Design
+
+### Layout Change
+
+Current lightbox metadata layout:
+```
+        Title (centered)
+  ─────────────────────────
+     Description (centered)
+```
+
+New lightbox metadata layout:
+```
+  Title                  🔍+
+  ─────────────────────────
+     Description (centered)
+```
+
+The title and magnifying glass share a flex row container constrained to the lightbox image width. The title is left-aligned and the icon is right-aligned.
+
+### Image URL Strategy
+
+Hugo will publish the original source image by referencing `$img.RelPermalink` (the unprocessed resource). This URL is stored in a `data-original` attribute on each gallery thumbnail link. When the magnifying glass is clicked, JavaScript opens this URL in a new tab via `window.open()`.
+
+### SVG Icon
+
+An inline SVG magnifying glass with a + sign inside the lens:
+```svg
+<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+  <circle cx="10" cy="10" r="7"/>
+  <line x1="16" y1="16" x2="22" y2="22"/>
+  <line x1="7" y1="10" x2="13" y2="10"/>
+  <line x1="10" y1="7" x2="10" y2="13"/>
+</svg>
+```
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `layouts/photography/list.html` | Add `data-original` attr to thumbnail links; wrap title + icon in `.lightbox-title-row`; add magnifying glass button; update JS to set original URL and handle click |
+| `assets/css/extended/custom.css` | Add `.lightbox-title-row` flex container; style `.lightbox-fullsize-btn`; adjust `.lightbox-title` alignment |
+
+## Test Plan
+
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [x] Site renders correctly on localhost (`hugo server -D`)
+- [ ] Magnifying glass icon appears in lightbox view on the photography page
+- [ ] Icon is right-aligned on the same row as the title, within image width
+- [ ] Clicking the icon opens the original full-resolution image in a new tab
+- [x] Icon does NOT appear on the homepage photo strip lightbox
+- [ ] Icon has proper hover effect and tooltip
+- [ ] Keyboard navigation still works (arrows, Escape)
+- [ ] Title row width syncs with the image width on resize/navigation

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -564,6 +564,37 @@ h6 { font-size: 1rem; line-height: 1.6; letter-spacing: 0; margin-bottom: 0.25em
     flex-shrink: 0;
 }
 
+.lightbox-fullsize-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: rgba(255, 255, 255, 0.35);
+    font-family: "Roboto Slab", serif;
+    font-size: 0.75rem;
+    font-weight: 300;
+    letter-spacing: 0.04rem;
+    border: none;
+    cursor: pointer;
+    transition: color 0.15s linear;
+    margin-top: 0.4rem;
+    flex-shrink: 0;
+}
+
+.lightbox-fullsize-link:hover {
+    color: rgba(255, 255, 255, 0.6);
+    border: none;
+}
+
+.lightbox-fullsize-link:visited {
+    color: rgba(255, 255, 255, 0.35);
+    border: none;
+}
+
+.lightbox-fullsize-link svg {
+    width: 0.85rem;
+    height: 0.85rem;
+}
+
 .lightbox-rule {
     border: 0;
     border-top: 1px solid rgba(255, 255, 255, 0.2);

--- a/layouts/photography/list.html
+++ b/layouts/photography/list.html
@@ -8,7 +8,8 @@
        data-slug="{{ .File.ContentBaseName }}"
        data-alt="{{ with .Params.alt }}{{ . }}{{ else }}{{ .Title }}{{ end }}"
        data-title="{{ .Title }}"
-       data-description="{{ .Params.description }}">
+       data-description="{{ .Params.description }}"
+       data-original="{{ $img.RelPermalink }}">
         {{- $thumb := $img.Fill "300x300 webp q80" }}
         <img src="{{ $thumb.RelPermalink }}" alt="{{ with .Params.alt }}{{ . }}{{ else }}{{ .Title }}{{ end }}" class="photo-thumb" loading="lazy" />
     </a>
@@ -34,6 +35,10 @@
             <div class="lightbox-title"></div>
             <hr class="lightbox-rule" />
             <div class="lightbox-description"></div>
+            <a class="lightbox-fullsize-link" href="#" target="_blank" rel="noopener" aria-label="View full resolution image">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                Full Resolution
+            </a>
         </div>
     </div>
 </div>
@@ -93,6 +98,7 @@
     var ruleEl = overlay.querySelector('.lightbox-rule');
     var headerRuleEl = overlay.querySelector('.lightbox-header-rule');
     var imgAndMeta = overlay.querySelector('.lightbox-img-and-meta');
+    var fullsizeLink = overlay.querySelector('.lightbox-fullsize-link');
     var currentIndex = -1;
     var showGen = 0;
 
@@ -139,6 +145,7 @@
                 descEl.textContent = link.dataset.description || '';
                 titleEl.style.display = link.dataset.title ? '' : 'none';
                 descEl.style.display = link.dataset.description ? '' : 'none';
+                fullsizeLink.href = link.dataset.original || link.href;
                 requestAnimationFrame(function() {
                     if (gen !== showGen) return;
                     syncRuleWidths();
@@ -196,10 +203,14 @@
     });
 
     closeBtn.addEventListener('click', closeLightbox);
+    fullsizeLink.addEventListener('click', function(e) {
+        e.stopPropagation();
+    });
     overlay.addEventListener('click', function(e) {
         if (e.target === img) return;
         if (e.target.closest('.lightbox-nav')) return;
         if (e.target.closest('.lightbox-site-title')) return;
+        if (e.target.closest('.lightbox-fullsize-link')) return;
         closeLightbox();
     });
     document.addEventListener('keydown', function(e) {


### PR DESCRIPTION
## Summary
- Adds a subtle "Full Resolution" link with download arrow icon below the description in the photography lightbox
- Styled as part of the image placard (muted gray, small text, Roboto Slab font) — unobtrusive until needed
- Clicking opens the original unprocessed source image in a new browser tab
- Only appears in the photography gallery lightbox — not on the homepage photo strip

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [x] Site renders correctly on localhost (`hugo server -D`)
- [ ] "Full Resolution" link appears below description in lightbox view
- [ ] Clicking the link opens the original full-resolution image in a new tab
- [x] Link does NOT appear on the homepage photo strip lightbox
- [ ] Link has subtle hover effect (brightens from 0.35 to 0.6 opacity)
- [ ] Keyboard navigation still works (arrows, Escape)
- [ ] Title remains centered

Generated with [Claude Code](https://claude.com/claude-code)