### PR TITLE
fix: watermark full-resolution photography downloads

### DIFF
--- a/.specs/041-fix-gallery-fullres-watermark.md
+++ b/.specs/041-fix-gallery-fullres-watermark.md
@@ -1,0 +1,59 @@
+# 041: Fix Gallery Full-Res Watermark
+
+**Branch**: `feature/fix-gallery-fullres-watermark`
+**Created**: 2026-03-03
+
+## Summary
+
+The "Full Resolution" link in the photography lightbox serves the raw, unwatermarked source image. All images except thumbnails should have the watermark in the bottom-right corner. This fix creates a full-resolution watermarked version for the download link.
+
+## Requirements
+
+- Full Resolution link must serve a watermarked image (not the raw source)
+- Watermark positioned in bottom-right corner with 15px padding (matching existing lightbox behavior)
+- Full-res image resized to max 2400px wide (original dims cause WebP OOM), converted to WebP q90
+- Raw source images must not be published/accessible
+- Thumbnails (300x300) remain unwatermarked
+- Lightbox display image (1600px) remains watermarked as-is
+
+## Design
+
+### New Partial: `fullres-image.html`
+
+Create `layouts/partials/photography/fullres-image.html` that:
+1. Takes an image resource as input
+2. Resizes to max 2400px wide, converts to WebP at q90 quality
+3. Overlays `assets/images/watermark.png` in bottom-right corner with 15px padding
+4. Returns the processed image resource
+
+### Template Change
+
+In `layouts/photography/list.html`, replace:
+```go
+data-original="{{ $img.RelPermalink }}"
+```
+with:
+```go
+{{- $fullres := partial "photography/fullres-image.html" $img }}
+data-original="{{ $fullres.RelPermalink }}"
+```
+
+This ensures `$img.RelPermalink` is never called, so Hugo won't publish the raw source.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `layouts/partials/photography/fullres-image.html` | **New** — full-res watermark partial |
+| `layouts/photography/list.html` | Replace `data-original` to use watermarked full-res |
+
+## Test Plan
+
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [ ] Site renders correctly on localhost (`hugo server -D`)
+- [ ] Full Resolution link opens a watermarked image (not raw source)
+- [ ] Watermark visible in bottom-right corner of full-res image
+- [ ] Lightbox display image still watermarked at 1600px
+- [ ] Thumbnails remain unwatermarked
+- [ ] Homepage photo clicks still deep-link to gallery lightbox
+- [ ] Gallery prev/next navigation works correctly

--- a/layouts/partials/photography/fullres-image.html
+++ b/layouts/partials/photography/fullres-image.html
@@ -1,0 +1,7 @@
+{{- $img := . -}}
+{{- $fullres := $img.Process "resize 2400x webp q90" -}}
+{{- $watermark := resources.Get "images/watermark.png" -}}
+{{- $x := sub $fullres.Width (add $watermark.Width 15) -}}
+{{- $y := sub $fullres.Height (add $watermark.Height 15) -}}
+{{- $fullres = $fullres.Filter (images.Overlay $watermark $x $y) -}}
+{{- return $fullres -}}

--- a/layouts/photography/list.html
+++ b/layouts/photography/list.html
@@ -9,7 +9,7 @@
        data-alt="{{ with .Params.alt }}{{ . }}{{ else }}{{ .Title }}{{ end }}"
        data-title="{{ .Title }}"
        data-description="{{ .Params.description }}"
-       data-original="{{ $img.RelPermalink }}">
+       data-original="{{ (partial "photography/fullres-image.html" $img).RelPermalink }}">
         {{- $thumb := $img.Fill "300x300 webp q80" }}
         <img src="{{ $thumb.RelPermalink }}" alt="{{ with .Params.alt }}{{ . }}{{ else }}{{ .Title }}{{ end }}" class="photo-thumb" loading="lazy" />
     </a>


### PR DESCRIPTION
## Summary
- The "Full Resolution" link in the photography lightbox was serving the raw, unwatermarked source image
- Added new `fullres-image.html` partial that processes images at 2400px wide (WebP q90) with watermark overlay
- Raw source images are no longer published — all non-thumbnail images now carry the watermark

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [ ] Site renders correctly on localhost (`hugo server -D`)
- [ ] Full Resolution link opens a watermarked image (not raw source)
- [ ] Watermark visible in bottom-right corner of full-res image
- [ ] Lightbox display image still watermarked at 1600px
- [ ] Thumbnails remain unwatermarked
- [ ] Homepage photo clicks still deep-link to gallery lightbox
- [ ] Gallery prev/next navigation works correctly

Generated with [Claude Code](https://claude.com/claude-code)