### PR TITLE
fix: remove obsolete Cloudflare Pages project creation step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,15 +34,6 @@ jobs:
       - name: Generate CSP headers
         run: node scripts/generate-headers.js
 
-      - name: Create Cloudflare Pages project (if needed)
-        if: github.ref == 'refs/heads/main'
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages project create mrmatt-io --production-branch=main
-        continue-on-error: true
-
       - name: Build Cloudflare Functions
         if: github.ref == 'refs/heads/main'
         uses: cloudflare/wrangler-action@v3

--- a/.specs/043-fix-deploy-error.md
+++ b/.specs/043-fix-deploy-error.md
@@ -1,0 +1,28 @@
+# 043: Remove Obsolete Cloudflare Project Creation Step
+
+**Branch**: `feature/fix-deploy-error`
+**Created**: 2026-03-05
+
+## Summary
+
+The deploy workflow has a "Create Cloudflare Pages project" step that always fails because the project already exists. Although `continue-on-error: true` prevents it from blocking the deploy, it logs a noisy error on every run. Remove the step since the project was created long ago and will never need to be recreated.
+
+## Requirements
+
+- Remove the "Create Cloudflare Pages project (if needed)" step from `.github/workflows/deploy.yml`
+- Do not change any other workflow steps
+
+## Design
+
+Delete lines 37-44 of `deploy.yml` (the `Create Cloudflare Pages project` step). No other changes needed.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `.github/workflows/deploy.yml` | Remove the "Create Cloudflare Pages project (if needed)" step |
+
+## Test Plan
+
+- [x] Deploy workflow YAML is valid
+- [x] No other steps are affected


### PR DESCRIPTION
## Summary
- The deploy workflow's "Create Cloudflare Pages project" step always fails because the project already exists
- Although `continue-on-error: true` prevents it from blocking deploys, it logs a noisy error on every run
- Removed the step since the project was created long ago and will never need to be recreated

## Test plan
- [x] Deploy workflow YAML is valid
- [x] No other steps are affected

Generated with [Claude Code](https://claude.com/claude-code)