### PR TITLE
feat: branded 404 page and prefers-reduced-motion support

### DIFF
--- a/.specs/044-404-and-reduced-motion.md
+++ b/.specs/044-404-and-reduced-motion.md
@@ -1,0 +1,48 @@
+# 044: Custom 404 Page & Prefers-Reduced-Motion
+
+**Branch**: `feature/404-and-reduced-motion`
+**Created**: 2026-03-05
+
+## Summary
+
+Add a branded 404 page with the site avatar and a friendly message instead of the generic Cloudflare 404. Also add `prefers-reduced-motion: reduce` support to disable all CSS transitions and the lightbox JS transition, respecting users who have motion sensitivity.
+
+## Requirements
+
+- Custom 404 page with avatar, "Page not found" message, and link home
+- 404 page should use the same layout/styling as the rest of the site (header, footer)
+- `prefers-reduced-motion: reduce` disables all CSS `transition` properties
+- Lightbox JS fade transition (150ms setTimeout in `showPhoto`) should be skipped when reduced motion is preferred
+- The existing `prefers-reduced-motion` check in PaperMod's footer.html smooth scrolling should remain untouched
+
+## Design
+
+### 404 Page
+Override PaperMod's minimal `layouts/404.html` with a branded version that:
+- Uses Hugo Pipes to process the avatar (same as homepage: `Fit "350x350 webp q85"`)
+- Shows the avatar at a smaller size (120x120), "Page not found" heading, friendly message, and a "Go home" link
+- Styled via a small `.not-found` section in `custom.css`, centered layout
+
+### Reduced Motion
+Add a single `@media (prefers-reduced-motion: reduce)` block at the end of `custom.css` that sets `transition: none !important` on all animated elements (or use `*` selector for simplicity since there are no CSS animations to preserve).
+
+In `layouts/photography/list.html`, check `window.matchMedia('(prefers-reduced-motion: reduce)')` and skip the 150ms fade timeout in `showPhoto` when true.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `layouts/404.html` | Create — branded 404 page with avatar and home link |
+| `assets/css/extended/custom.css` | Add `.not-found` styles and `prefers-reduced-motion` media query |
+| `layouts/photography/list.html` | Skip lightbox fade transition when reduced motion preferred |
+
+## Test Plan
+
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [x] `node scripts/generate-headers.js` succeeds
+- [x] 404 page renders at any non-existent URL (e.g., `/nonexistent/`)
+- [x] 404 page shows avatar, heading, message, and home link
+- [ ] 404 page works in dark mode
+- [ ] With `prefers-reduced-motion: reduce` enabled in OS/browser, no CSS transitions occur on hover or lightbox
+- [ ] Lightbox photo switching is instant (no fade) with reduced motion enabled
+- [ ] With reduced motion disabled, all transitions work as before

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -963,3 +963,73 @@ hr {
 [data-theme="dark"] .related-posts li::before {
     color: var(--primary);
 }
+
+/* ===== 404 page ===== */
+
+.not-found {
+    position: static;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    height: auto;
+    font-size: inherit;
+    font-weight: inherit;
+    text-align: center;
+    padding: 5rem 1rem 3rem;
+}
+
+.not-found-avatar {
+    width: 150px;
+    height: 150px;
+    border-radius: 50%;
+    object-fit: cover;
+    margin-bottom: 2rem;
+    opacity: 0.85;
+}
+
+.not-found-code {
+    font-size: 5rem;
+    font-weight: 300;
+    letter-spacing: -0.15rem;
+    line-height: 1;
+    margin-bottom: 0.5rem;
+}
+
+.not-found-message {
+    color: var(--secondary);
+    font-size: 1.1rem;
+    margin-bottom: 2rem;
+}
+
+.not-found-home {
+    font-family: monospace;
+    font-size: 1rem;
+    padding: 0.6rem 1.5rem;
+    border: 2px solid #b9cadb;
+    border-radius: 4px;
+    color: #090909;
+    transition: border-color 0.15s linear, color 0.15s linear;
+}
+
+.not-found-home:hover {
+    border-color: #4c81b2;
+    color: #4c81b2;
+}
+
+[data-theme="dark"] .not-found-home {
+    color: var(--primary);
+    border-color: var(--tertiary);
+}
+
+[data-theme="dark"] .not-found-home:hover {
+    border-color: rgba(76, 129, 178, 0.7);
+    color: rgba(76, 129, 178, 0.9);
+}
+
+/* ===== Reduced motion ===== */
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        transition: none !important;
+    }
+}

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,10 @@
+{{- define "main" }}
+<div class="not-found">
+    {{- $avatar := resources.Get "images/MattWalker-avatar.png" }}
+    {{- $avatarWebp := $avatar.Fit "350x350 webp q85" }}
+    <img src="{{ $avatarWebp.RelPermalink }}" alt="Illustrated avatar of Matt Walker" class="not-found-avatar" width="150" height="150" />
+    <div class="not-found-code">404</div>
+    <p class="not-found-message">Nothing's deployed here.</p>
+    <a href="/" class="not-found-home">cd ~</a>
+</div>
+{{- end }}

--- a/layouts/photography/list.html
+++ b/layouts/photography/list.html
@@ -120,6 +120,8 @@
         if (slug) slugMap[slug] = i;
     });
 
+    var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
     function showPhoto(index) {
         if (index < 0 || index >= allItems.length) return;
         currentIndex = index;
@@ -157,7 +159,9 @@
                     imgAndMeta.classList.remove('lightbox-transitioning');
                 });
             }
-            if (hadSrc) {
+            if (prefersReducedMotion) {
+                applyContent();
+            } else if (hadSrc) {
                 imgAndMeta.classList.add('lightbox-transitioning');
                 setTimeout(applyContent, 150);
             } else {


### PR DESCRIPTION
## Summary
- Branded 404 page with avatar, big "404", developer-flavored copy ("Nothing's deployed here."), and `cd ~` home button
- Override PaperMod's default 404 styles (absolute positioning, 160px font)
- `prefers-reduced-motion: reduce` disables all CSS transitions site-wide
- Lightbox JS fade transition skipped when reduced motion is preferred

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [x] `node scripts/generate-headers.js` succeeds
- [x] 404 page renders at any non-existent URL (e.g., `/nonexistent/`)
- [x] 404 page shows avatar, heading, message, and home link
- [ ] 404 page works in dark mode
- [ ] With `prefers-reduced-motion: reduce` enabled in OS/browser, no CSS transitions occur on hover or lightbox
- [ ] Lightbox photo switching is instant (no fade) with reduced motion enabled
- [ ] With reduced motion disabled, all transitions work as before

Generated with [Claude Code](https://claude.com/claude-code)