### PR TITLE
feat: styled RSS feed with image thumbnails

### DIFF
--- a/.specs/047-rss-feed.md
+++ b/.specs/047-rss-feed.md
@@ -1,0 +1,62 @@
+# 047: Styled RSS Feed with Image Thumbnails
+
+**Branch**: `feature/rss-feed`
+**Created**: 2026-03-09
+
+## Summary
+
+Add a polished RSS feed experience: a styled RSS page (XSLT) that renders beautifully in browsers instead of raw XML, image thumbnails for each post via `<media:content>` tags using cover/OG images, and a subtle "Feed" link in the site footer matching the existing link style.
+
+## Requirements
+
+- Add RSS text link ("Feed") to the footer, matching existing inline link style (no icons, no orange badges)
+- Override PaperMod's RSS template to include `<media:content>` tags with post cover images
+- Fall back to site default image (`/images/MattWalker-avatar.png`) for posts without cover images
+- Create an XSL stylesheet that transforms the RSS XML into a styled HTML page when viewed in a browser
+- XSL page must match site typography (Roboto Slab), color scheme, and minimal aesthetic
+- XSL page should include a brief explanation of what RSS is and how to subscribe
+- Support dark mode in the XSL stylesheet via `prefers-color-scheme`
+- Show post thumbnails in the styled feed page when available
+
+## Design
+
+### RSS Template (`layouts/_default/rss.xml`)
+- Copy PaperMod's template, add `xmlns:media` namespace
+- Add `<?xml-stylesheet?>` processing instruction pointing to `/rss.xsl`
+- For each item, add `<media:content>` with the post's `cover.image` (or site default)
+- Use `absURL` to ensure full URLs for images
+
+### XSL Stylesheet (`static/rss.xsl`)
+- Transforms RSS 2.0 XML into clean HTML
+- Self-contained: all CSS is inlined (since it renders as a standalone page)
+- Typography: Roboto Slab from Google Fonts (self-hosted fonts won't work here since XSL generates its own document)
+- Colors: match site (#090909 text, #fff background, #b9cadb accent, #4c81b2 hover)
+- Dark mode: `prefers-color-scheme: dark` media query with site's dark palette
+- Layout: centered content, max-width ~40em, generous whitespace
+- Header: site title + subtitle explaining "This is an RSS feed"
+- Each post: title (linked), date, description, thumbnail if available
+- Footer: link back to site
+
+### Footer Link
+- Add "Feed" as a text link to `/index.xml` in the footer's `<ul class="footer-links">`
+- Placed after "Creative Commons" as the last item
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `layouts/_default/rss.xml` | Updated — added XSL stylesheet reference, media namespace, and media:content tags |
+| `static/rss.xsl` | New file — XSL stylesheet for browser-rendered feed page |
+| `layouts/partials/footer.html` | Add "Feed" link to footer-links list |
+
+## Test Plan
+
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [ ] Site renders correctly on localhost (`hugo server -D`)
+- [x] RSS feed at `/index.xml` is valid XML with media:content tags
+- [x] RSS feed includes XSL stylesheet reference
+- [ ] Viewing `/index.xml` in a browser shows styled HTML page (not raw XML)
+- [ ] Footer shows "Feed" link styled consistently with other links
+- [x] Posts with cover images show thumbnails in feed
+- [x] Posts without cover images fall back to default site image
+- [ ] Dark mode works on the styled feed page

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -2,6 +2,8 @@
      - Channel <description> uses site.Params.description
      - <content:encoded> includes full post content for feed readers
      - <managingEditor> renders author name even without email
+     - XSL stylesheet for styled browser rendering
+     - <media:content> for post cover/OG images
 */ -}}
 {{- $authorEmail := "" }}
 {{- $authorName := "" }}
@@ -31,7 +33,8 @@
 {{- $pages = $pages | first $limit }}
 {{- end }}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
+{{ printf "<?xml-stylesheet type=\"text/xsl\" href=\"%s\"?>" ("/rss.xsl" | absURL) | safeHTML }}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:media="http://search.yahoo.com/mrss/">
   <channel>
     <title>{{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
@@ -62,8 +65,24 @@
       <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Summary | transform.XMLEscape | safeHTML }}</description>
+      <description>{{ with .Description }}{{ . | transform.XMLEscape | safeHTML }}{{ else }}{{ .Summary | plainify | transform.XMLEscape | safeHTML }}{{ end }}</description>
       <content:encoded>{{ .Content | transform.XMLEscape | safeHTML }}</content:encoded>
+      {{- /* Determine media image: cover → photography page resource → site default */ -}}
+      {{- $mediaURL := "" -}}
+      {{- with .Params.cover }}{{ with .image }}{{ $mediaURL = . | absURL }}{{ end }}{{ end -}}
+      {{- if and (not $mediaURL) (eq .Section "photography") -}}
+        {{- $img := .Resources.GetMatch "*.{jpg,jpeg,png,webp}" -}}
+        {{- if $img -}}
+          {{- $thumb := $img.Process "fill 240x240 webp q80" -}}
+          {{- $mediaURL = $thumb.Permalink -}}
+        {{- end -}}
+      {{- end -}}
+      {{- if not $mediaURL -}}
+        {{- with site.Params.images }}{{ $mediaURL = index . 0 | absURL }}{{ end -}}
+      {{- end -}}
+      {{- if $mediaURL }}
+      <media:content url="{{ $mediaURL }}" medium="image" />
+      {{- end }}
     </item>
     {{- end }}
   </channel>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -8,6 +8,7 @@
         <li><a href="/now/">Now</a></li>
         <li><a href="https://www.linkedin.com/in/mrmatt" target="_blank" rel="me noopener">LinkedIn</a></li>
         <li><a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">Creative Commons</a></li>
+        <li><a href="/index.xml">Feed</a></li>
     </ul>
 </footer>
 {{- end }}

--- a/static/rss.xsl
+++ b/static/rss.xsl
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="3.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  xmlns:media="http://search.yahoo.com/mrss/">
+
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes" />
+
+  <xsl:template match="/">
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title><xsl:value-of select="/rss/channel/title" /> — Feed</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
+        <link href="https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@300;400;600&amp;display=swap" rel="stylesheet" />
+        <style>
+          *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+          body {
+            font-family: "Roboto Slab", serif;
+            font-weight: 300;
+            color: #090909;
+            background: #fff;
+            line-height: 1.7;
+            -webkit-font-smoothing: antialiased;
+          }
+
+          .wrapper {
+            max-width: 40em;
+            width: 90%;
+            margin: 0 auto;
+            padding: 3rem 0 4rem;
+          }
+
+          .feed-header {
+            margin-bottom: 3rem;
+          }
+
+          .feed-header h1 {
+            font-size: 1.75rem;
+            font-weight: 600;
+            letter-spacing: -0.02em;
+            margin-bottom: 0.5rem;
+          }
+
+          .feed-header h1 a {
+            color: #090909;
+            text-decoration: none;
+            border-bottom: 2px solid #b9cadb;
+            transition: border-color 0.15s linear;
+          }
+
+          .feed-header h1 a:hover {
+            border-bottom-color: #4c81b2;
+          }
+
+          .feed-notice {
+            font-size: 0.95rem;
+            color: #555;
+            line-height: 1.6;
+            margin-bottom: 1rem;
+          }
+
+          .feed-notice strong {
+            font-weight: 600;
+            color: #090909;
+          }
+
+          .feed-notice code {
+            font-size: 0.85em;
+            background: #f4f4f4;
+            padding: 0.15em 0.4em;
+            border-radius: 3px;
+          }
+
+          .feed-url {
+            display: inline-block;
+            font-size: 0.85rem;
+            color: #555;
+            background: #f4f4f4;
+            padding: 0.4em 0.75em;
+            border-radius: 4px;
+            font-family: monospace;
+            word-break: break-all;
+            margin-top: 0.5rem;
+          }
+
+          hr {
+            border: 0;
+            border-top: 1px solid #e1e1e1;
+            margin: 2rem 0;
+          }
+
+          .feed-item {
+            display: flex;
+            gap: 1.25rem;
+            align-items: flex-start;
+            padding: 1.5rem 0;
+            border-bottom: 1px solid #f0f0f0;
+          }
+
+          .feed-item:last-child {
+            border-bottom: none;
+          }
+
+          .feed-item-thumb {
+            flex-shrink: 0;
+            width: 80px;
+            height: 80px;
+            border-radius: 50%;
+            object-fit: cover;
+          }
+
+          .feed-item-content {
+            flex: 1;
+            min-width: 0;
+          }
+
+          .feed-item-title {
+            font-size: 1.1rem;
+            font-weight: 600;
+            letter-spacing: -0.01em;
+            margin-bottom: 0.25rem;
+          }
+
+          .feed-item-title a {
+            color: #090909;
+            text-decoration: none;
+            border-bottom: 2px solid transparent;
+            transition: border-color 0.15s linear;
+          }
+
+          .feed-item-title a:hover {
+            border-bottom-color: #4c81b2;
+          }
+
+          .feed-item-date {
+            font-size: 0.8rem;
+            color: #888;
+            margin-bottom: 0.4rem;
+          }
+
+          .feed-item-desc {
+            font-size: 0.9rem;
+            color: #444;
+            line-height: 1.55;
+          }
+
+          .feed-footer {
+            text-align: center;
+            padding-top: 2rem;
+            font-size: 0.85rem;
+            color: #888;
+          }
+
+          .feed-footer a {
+            color: #090909;
+            text-decoration: none;
+            border-bottom: 2px solid #b9cadb;
+            transition: border-color 0.15s linear;
+          }
+
+          .feed-footer a:hover {
+            border-bottom-color: #4c81b2;
+          }
+
+          @media (prefers-color-scheme: dark) {
+            body { background: #1d1e20; color: #d1d1d1; }
+
+            .feed-header h1 a { color: #d1d1d1; border-bottom-color: rgba(185, 202, 219, 0.3); }
+            .feed-header h1 a:hover { border-bottom-color: rgba(76, 129, 178, 0.7); }
+
+            .feed-notice { color: #999; }
+            .feed-notice strong { color: #d1d1d1; }
+            .feed-notice code { background: #2a2b2d; color: #d1d1d1; }
+
+            .feed-url { background: #2a2b2d; color: #999; }
+
+            hr { border-top-color: #333; }
+
+            .feed-item { border-bottom-color: #2a2b2d; }
+            .feed-item-thumb { }
+            .feed-item-title a { color: #d1d1d1; }
+            .feed-item-title a:hover { border-bottom-color: rgba(76, 129, 178, 0.7); }
+            .feed-item-date { color: #777; }
+            .feed-item-desc { color: #999; }
+
+            .feed-footer { color: #666; }
+            .feed-footer a { color: #d1d1d1; border-bottom-color: rgba(185, 202, 219, 0.3); }
+            .feed-footer a:hover { border-bottom-color: rgba(76, 129, 178, 0.7); }
+          }
+
+          @media (max-width: 480px) {
+            .feed-item-thumb { width: 60px; height: 60px; }
+            .feed-item { gap: 1rem; }
+          }
+        </style>
+      </head>
+      <body>
+        <div class="wrapper">
+          <header class="feed-header">
+            <h1>
+              <a>
+                <xsl:attribute name="href">
+                  <xsl:value-of select="/rss/channel/link" />
+                </xsl:attribute>
+                <xsl:value-of select="/rss/channel/title" />
+              </a>
+            </h1>
+            <p class="feed-notice">
+              <strong>You're looking at an RSS feed.</strong>
+              Subscribe by copying the URL into your reader of choice.
+            </p>
+            <span class="feed-url">
+              <xsl:value-of select="/rss/channel/atom:link[@rel='self']/@href" />
+            </span>
+          </header>
+
+          <hr />
+
+          <xsl:for-each select="/rss/channel/item">
+            <article class="feed-item">
+              <xsl:if test="media:content/@url">
+                <img class="feed-item-thumb" loading="lazy">
+                  <xsl:attribute name="src">
+                    <xsl:value-of select="media:content/@url" />
+                  </xsl:attribute>
+                  <xsl:attribute name="alt">
+                    <xsl:value-of select="title" />
+                  </xsl:attribute>
+                </img>
+              </xsl:if>
+              <div class="feed-item-content">
+                <h2 class="feed-item-title">
+                  <a>
+                    <xsl:attribute name="href">
+                      <xsl:value-of select="link" />
+                    </xsl:attribute>
+                    <xsl:value-of select="title" />
+                  </a>
+                </h2>
+                <time class="feed-item-date">
+                  <xsl:value-of select="pubDate" />
+                </time>
+                <xsl:if test="string-length(description) &gt; 0">
+                  <p class="feed-item-desc">
+                    <xsl:value-of select="description" />
+                  </p>
+                </xsl:if>
+              </div>
+            </article>
+          </xsl:for-each>
+
+          <footer class="feed-footer">
+            <a>
+              <xsl:attribute name="href">
+                <xsl:value-of select="/rss/channel/link" />
+              </xsl:attribute>
+              <xsl:value-of select="/rss/channel/title" />
+            </a>
+          </footer>
+        </div>
+      </body>
+    </html>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
## Summary
- Add XSL stylesheet that renders `/index.xml` as a styled HTML page in browsers (Roboto Slab, site colors, dark mode)
- Enhance RSS template with `<media:content>` tags — uses cover images for posts, actual photos for photography pages, avatar fallback
- Add subtle "Feed" text link in footer, matching existing link style
- Use plain-text descriptions in RSS (front matter `description` preferred, `plainify` fallback)

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [ ] Site renders correctly on localhost (`hugo server -D`)
- [x] RSS feed at `/index.xml` is valid XML with media:content tags
- [x] RSS feed includes XSL stylesheet reference
- [ ] Viewing `/index.xml` in a browser shows styled HTML page (not raw XML)
- [ ] Footer shows "Feed" link styled consistently with other links
- [x] Posts with cover images show thumbnails in feed
- [x] Posts without cover images fall back to default site image
- [ ] Dark mode works on the styled feed page

Generated with [Claude Code](https://claude.com/claude-code)