### PR TITLE
feat: add scroll progress bar to blog post pages

### DIFF
--- a/.specs/048-scroll-progress-bar.md
+++ b/.specs/048-scroll-progress-bar.md
@@ -1,0 +1,51 @@
+# 048: Scroll Progress Bar
+
+**Branch**: `feat/scroll-progress-bar`
+**Created**: 2026-03-09
+
+## Summary
+
+Add a thin scroll progress indicator bar at the very top of the viewport on single blog post pages. As the user scrolls through a post, the bar fills from left to right showing reading progress (0% at top, 100% at bottom).
+
+## Requirements
+
+- Thin colored bar (3px tall) fixed at the very top of the viewport
+- Fills from 0% width to 100% width as user scrolls from top to bottom
+- Uses a complementary accent color that works in both light and dark mode
+- Only appears on single blog post pages (not homepage, list pages, photography, etc.)
+- Respects `prefers-reduced-motion: reduce` (hidden entirely when motion is reduced)
+- No npm/node dependencies, no external JS frameworks
+- Minimal vanilla JS to track scroll position and update bar width
+
+## Design
+
+### Progress Bar Element
+A `<div class="scroll-progress">` element added to the single post layout (`layouts/_default/single.html`), positioned fixed at the top of the viewport with `z-index` above the header.
+
+### Colors
+- Light mode: `#4c81b2` (the site's existing accent blue, used for link hover states)
+- Dark mode: `rgba(76, 129, 178, 0.8)` (slightly transparent version of the same blue)
+
+### JavaScript
+A small inline `<script>` at the end of the single template that:
+1. Gets the `.scroll-progress` element
+2. On scroll, calculates `scrollTop / (scrollHeight - clientHeight)` as a ratio
+3. Sets the bar width as a percentage via `style.width`
+4. Skipped entirely when `prefers-reduced-motion: reduce` is active
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `layouts/_default/single.html` | Add progress bar `<div>` and inline scroll tracking script |
+| `assets/css/extended/custom.css` | Add `.scroll-progress` styles and reduced-motion hiding |
+
+## Test Plan
+
+- [ ] Hugo builds with no errors (`hugo --minify`)
+- [ ] Progress bar appears on blog post pages
+- [ ] Progress bar does NOT appear on homepage, list pages, or photography pages
+- [ ] Bar fills from 0% to 100% as user scrolls through a post
+- [ ] Works correctly in both light and dark mode
+- [ ] Bar is hidden when `prefers-reduced-motion: reduce` is enabled
+- [ ] Bar is positioned above the header, at the very top of the viewport

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -1026,10 +1026,30 @@ hr {
     color: rgba(76, 129, 178, 0.9);
 }
 
+/* ===== Scroll progress bar (blog posts only) ===== */
+
+.scroll-progress {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 0%;
+    height: 3px;
+    background: #4c81b2;
+    z-index: 9999;
+    pointer-events: none;
+}
+
+[data-theme="dark"] .scroll-progress {
+    background: rgba(76, 129, 178, 0.8);
+}
+
 /* ===== Reduced motion ===== */
 
 @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {
         transition: none !important;
+    }
+    .scroll-progress {
+        display: none;
     }
 }

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,9 @@
 {{- define "main" }}
 
+{{- if eq .Section "posts" }}
+<div class="scroll-progress" aria-hidden="true"></div>
+{{- end }}
+
 <article class="post-single">
   <header class="post-header">
     {{ partial "breadcrumbs.html" . }}
@@ -63,5 +67,21 @@
 </article>
 
 {{- partial "related-posts.html" . }}
+
+{{- if eq .Section "posts" }}
+<script>
+(function() {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+  var bar = document.querySelector('.scroll-progress');
+  if (!bar) return;
+  function update() {
+    var h = document.documentElement.scrollHeight - document.documentElement.clientHeight;
+    bar.style.width = h > 0 ? (window.scrollY / h * 100) + '%' : '0%';
+  }
+  window.addEventListener('scroll', update, {passive: true});
+  update();
+})();
+</script>
+{{- end }}
 
 {{- end }}{{/* end main */}}


### PR DESCRIPTION
## Summary

- Adds a thin (3px) accent-colored scroll progress bar fixed at the very top of the viewport on blog post pages
- Bar fills left-to-right from 0% to 100% as the reader scrolls through the post content
- Only appears on single blog post pages (section `posts`) — not on homepage, list pages, photography, about, etc.

## Implementation

- **CSS** (`assets/css/extended/custom.css`): Fixed-position `.scroll-progress` div with `#4c81b2` accent blue in light mode, `rgba(76, 129, 178, 0.8)` in dark mode, `z-index: 9999`, `pointer-events: none`
- **HTML** (`layouts/_default/single.html`): Conditionally renders the progress bar div and a small inline `<script>` only when `.Section == "posts"`
- **JS**: ~10 lines of vanilla JS using passive scroll listener to compute `scrollY / (scrollHeight - clientHeight)` and set bar width
- **Accessibility**: `aria-hidden="true"` on the bar element; entirely hidden via `display: none` when `prefers-reduced-motion: reduce` is active (both CSS and JS bail out)

## Test plan

- [x] `hugo --minify` builds with no errors
- [x] `node scripts/generate-headers.js` succeeds (CSP hashes auto-computed)
- [x] Progress bar div present in blog post HTML output
- [x] Progress bar absent from homepage, about, now, and photography pages
- [ ] Bar fills 0%→100% when scrolling a blog post
- [ ] Works in both light and dark mode
- [ ] Hidden when `prefers-reduced-motion: reduce` is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)