### PR TITLE
feat: add blur-up LQIP placeholders to photography gallery

### DIFF
--- a/.specs/048-blur-up-placeholders.md
+++ b/.specs/048-blur-up-placeholders.md
@@ -1,0 +1,66 @@
+# 048: Blur-Up Placeholder Images
+
+**Branch**: `feat/blur-up-placeholders`
+**Created**: 2026-03-09
+
+## Summary
+
+Add blur-up placeholder images to the photography gallery so that lazy-loaded photos show a tiny blurred preview instead of empty space, transitioning smoothly to the sharp image once loaded.
+
+## Context
+
+The photography gallery currently uses `loading="lazy"` for thumbnail images and an IntersectionObserver-based progressive rendering system that reveals photos in batches as the user scrolls. When images are revealed but not yet loaded, the user sees empty space until the full thumbnail downloads. A blur-up placeholder improves perceived performance by immediately displaying a tiny, blurred version of each image.
+
+## Requirements
+
+### Hugo Image Processing (Build-Time)
+- Generate a tiny (20px wide) version of each gallery thumbnail using Hugo's image processing pipeline
+- Encode the tiny image as a base64 data URI for inline embedding
+- No additional npm/node dependencies — use Hugo's built-in `Resize` and `base64Encode` only
+
+### Gallery Grid (photography/list.html)
+- Add a `background-image` CSS inline style on each `<img>` tag with the base64 LQIP data URI
+- Apply CSS `background-size: cover` so the tiny image fills the thumbnail space
+- When the real image loads, it naturally covers the blurred background
+- Must work with the existing IntersectionObserver progressive rendering system
+
+### Homepage Photo Strip (layouts/index.html)
+- Apply the same blur-up treatment to the 7-photo strip on the homepage
+
+### CSS
+- Add a blur filter on the placeholder background using a wrapper element
+- Smooth transition from blurred placeholder to sharp image via opacity fade
+- Respect `prefers-reduced-motion` — skip animations for users who prefer reduced motion
+
+### Constraints
+- No npm/node dependencies
+- No external JS frameworks — vanilla JS only, minimal additions
+- Must not break existing lazy loading or lightbox functionality
+- Must work with existing WebP image pipeline
+
+## Implementation
+
+### Approach
+Use a CSS-based blur-up technique:
+1. Hugo generates a tiny ~20px base64 image at build time
+2. Each gallery thumbnail gets wrapped in a container that has the LQIP as a background image with CSS `filter: blur(20px)` and `background-size: cover`
+3. The real `<img>` starts with `opacity: 0` and fades in via CSS transition when loaded
+4. A small inline `onload` handler on each `<img>` adds a `loaded` class to trigger the opacity transition
+5. Fallback: `<noscript>` isn't needed since the existing gallery already requires JS for progressive rendering
+
+### Files Changed
+- `layouts/photography/list.html` — wrap thumbnails with LQIP container, generate base64 placeholders
+- `layouts/index.html` — same treatment for homepage photo strip
+- `assets/css/extended/custom.css` — blur-up container styles and transitions
+
+## Test Plan
+
+- [ ] Gallery grid shows blurred placeholders before images load
+- [ ] Smooth fade transition from placeholder to sharp image
+- [ ] Homepage photo strip has same blur-up effect
+- [ ] Lightbox still works correctly (click to open, navigation, close)
+- [ ] Progressive rendering (IntersectionObserver) still works
+- [ ] `prefers-reduced-motion` disables transition animations
+- [ ] `hugo server` runs with no errors
+- [ ] `hugo --minify` production build succeeds
+- [ ] No npm/node dependencies added

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -318,15 +318,42 @@ h6 { font-size: 1rem; line-height: 1.6; letter-spacing: 0; margin-bottom: 0.25em
     line-height: 0;
 }
 
+/* Blur-up placeholder wrapper */
+.photo-thumb-wrap {
+    position: relative;
+    overflow: hidden;
+    border-radius: 4px;
+    aspect-ratio: 1;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
+.photo-thumb-wrap::before {
+    content: "";
+    position: absolute;
+    inset: -10px;
+    background: inherit;
+    filter: blur(20px);
+    z-index: 0;
+}
+
 .photo-thumb {
+    position: relative;
     width: 100%;
     aspect-ratio: 1;
     object-fit: cover;
     border-radius: 4px;
-    transition: opacity 0.15s linear;
+    z-index: 1;
+    opacity: 0;
+    transition: opacity 0.4s ease;
 }
 
-.photo-thumb:hover {
+.photo-thumb.loaded {
+    opacity: 1;
+}
+
+.photo-thumb.loaded:hover {
     opacity: 0.85;
 }
 
@@ -427,12 +454,16 @@ h6 { font-size: 1rem; line-height: 1.6; letter-spacing: 0; margin-bottom: 0.25em
     margin: 1.5rem auto 3rem;
 }
 
+.photo-gallery-grid .photo-thumb-wrap {
+    width: 100%;
+}
+
 .photo-gallery-grid .photo-thumb {
     width: 100%;
     height: auto;
     aspect-ratio: 1;
     object-fit: cover;
-    border-radius: 4px;
+    border-radius: 0;
 }
 
 @media (min-width: 550px) {
@@ -919,11 +950,11 @@ hr {
     color: var(--primary);
 }
 
-[data-theme="dark"] .photo-thumb {
+[data-theme="dark"] .photo-thumb.loaded {
     opacity: 0.9;
 }
 
-[data-theme="dark"] .photo-thumb:hover {
+[data-theme="dark"] .photo-thumb.loaded:hover {
     opacity: 0.75;
 }
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -48,13 +48,16 @@
             {{- range first 7 $photos }}
             {{- $img := .Resources.GetMatch "*.{jpg,jpeg,png,webp}" }}
             {{- if $img }}
+            {{- $lqip := $img.Fill "20x20 webp q20" }}
             <a href="/photography/#{{ .File.ContentBaseName }}" class="photo-thumb-link no-underline">
                 {{- $thumb200 := $img.Fill "200x200 webp q80" }}
                 {{- $thumb300 := $img.Fill "300x300 webp q80" }}
+                <div class="photo-thumb-wrap" data-lqip="data:image/webp;base64,{{ $lqip.Content | base64Encode }}">
                 <img src="{{ $thumb300.RelPermalink }}"
                      srcset="{{ $thumb200.RelPermalink }} 200w, {{ $thumb300.RelPermalink }} 300w"
                      sizes="(max-width: 549px) calc(25vw - 0.5rem), 10em"
                      alt="{{ with .Params.alt }}{{ . }}{{ else }}{{ .Title }}{{ end }}" class="photo-thumb" loading="lazy" />
+                </div>
             </a>
             {{- end }}
             {{- end }}
@@ -64,5 +67,21 @@
         </div>
     </section>
 </div>
+<script>
+(function() {
+    document.querySelectorAll('.photo-thumb-wrap[data-lqip]').forEach(function(el) {
+        el.style.backgroundImage = 'url(' + el.dataset.lqip + ')';
+    });
+    document.querySelectorAll('.photo-thumb').forEach(function(img) {
+        if (img.complete && img.naturalWidth > 0) {
+            img.classList.add('loaded');
+        } else {
+            img.addEventListener('load', function() {
+                img.classList.add('loaded');
+            });
+        }
+    });
+})();
+</script>
 {{- end }}
 {{- end }}

--- a/layouts/photography/list.html
+++ b/layouts/photography/list.html
@@ -4,6 +4,7 @@
     {{- $img := .Resources.GetMatch "*.{jpg,jpeg,png,webp}" }}
     {{- if $img }}
     {{- $full := partial "photography/full-image.html" $img }}
+    {{- $lqip := $img.Fill "20x20 webp q20" }}
     <a href="{{ $full.RelPermalink }}" class="photo-thumb-link no-underline"
        data-slug="{{ .File.ContentBaseName }}"
        data-alt="{{ with .Params.alt }}{{ . }}{{ else }}{{ .Title }}{{ end }}"
@@ -13,10 +14,12 @@
         {{- $thumb200 := $img.Fill "200x200 webp q80" }}
         {{- $thumb300 := $img.Fill "300x300 webp q80" }}
         {{- $thumb450 := $img.Fill "450x450 webp q80" }}
+        <div class="photo-thumb-wrap" data-lqip="data:image/webp;base64,{{ $lqip.Content | base64Encode }}">
         <img src="{{ $thumb300.RelPermalink }}"
              srcset="{{ $thumb200.RelPermalink }} 200w, {{ $thumb300.RelPermalink }} 300w, {{ $thumb450.RelPermalink }} 450w"
              sizes="(max-width: 549px) calc(25vw - 0.5rem), 160px"
              alt="{{ with .Params.alt }}{{ . }}{{ else }}{{ .Title }}{{ end }}" class="photo-thumb" width="300" height="300" loading="lazy" />
+        </div>
     </a>
     {{- end }}
     {{- end }}
@@ -49,6 +52,22 @@
 </div>
 <script>
 (function() {
+    // Apply LQIP blur-up placeholders from data attributes
+    document.querySelectorAll('.photo-thumb-wrap[data-lqip]').forEach(function(el) {
+        el.style.backgroundImage = 'url(' + el.dataset.lqip + ')';
+    });
+
+    // Mark images as loaded for blur-up fade transition
+    document.querySelectorAll('.photo-thumb').forEach(function(img) {
+        if (img.complete && img.naturalWidth > 0) {
+            img.classList.add('loaded');
+        } else {
+            img.addEventListener('load', function() {
+                img.classList.add('loaded');
+            });
+        }
+    });
+
     // Progressive rendering: show photos in batches as user scrolls
     var BATCH_SIZE = 16;
     var allItems = Array.from(document.querySelectorAll('.photo-gallery-grid .photo-thumb-link'));


### PR DESCRIPTION
## Summary

- Generate tiny 20x20 WebP placeholder images at build time using Hugo's image processing pipeline
- Inline placeholders as base64 data URIs via `data-lqip` attributes (CSP-safe, no inline styles)
- Wrap each gallery thumbnail in a blur-up container that shows the placeholder immediately, then fades to the sharp image on load
- Applied to both the `/photography/` gallery grid (90 photos) and the homepage photo strip (7 photos)
- No npm/node dependencies, no external JS frameworks added

## Technical Details

- Hugo generates `20x20 webp q20` images and base64-encodes them inline (~100-200 bytes each)
- A CSS `::before` pseudo-element with `filter: blur(20px)` and `background: inherit` creates the blurred effect
- The real `<img>` starts at `opacity: 0` and transitions to `opacity: 1` via a `loaded` class added by JS on image load
- Existing `prefers-reduced-motion` global rule (`transition: none !important`) ensures no animations for users who prefer reduced motion
- Background images applied via JS (`el.style.backgroundImage`) to avoid CSP `style-src` violations from inline `style` attributes

## Test plan

- [ ] Gallery grid shows blurred placeholders before images load
- [ ] Smooth fade transition from placeholder to sharp image
- [ ] Homepage photo strip has same blur-up effect
- [ ] Lightbox still works correctly (click to open, navigation, close)
- [ ] Progressive rendering (IntersectionObserver batching) still works
- [ ] `prefers-reduced-motion` disables transition animations
- [ ] `hugo server` runs with no errors
- [ ] `hugo --minify` production build succeeds
- [ ] No npm/node dependencies added
- [ ] CSP headers do not block the blur-up placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)