### PR TITLE
feat: add dedicated photography RSS feed with media enclosures

### DIFF
--- a/.specs/048-photography-rss-feed.md
+++ b/.specs/048-photography-rss-feed.md
@@ -1,0 +1,62 @@
+# 048: Photography RSS Feed
+
+**Branch**: `feat/photography-rss-feed`
+**Created**: 2026-03-09
+
+## Summary
+
+Add a dedicated RSS feed for the photography section at `/photography/index.xml` with media enclosures for each photo, and a subtle RSS icon on the photography gallery page for feed discovery.
+
+## Background
+
+The site already has a main RSS feed at `/index.xml` using a custom template (`layouts/_default/rss.xml`). The photography section uses a custom layout (`layouts/photography/`) with its own `baseof.html` and `list.html`. Photo pages are page bundles under `content/photography/` with `photo.jpg` image resources.
+
+A dedicated photography RSS feed lets subscribers follow new photos without the blog post noise, and the `<enclosure>` tag enables photo-aware feed readers to display thumbnails inline.
+
+## Changes
+
+### 1. Enable RSS output for photography section (`hugo.toml`)
+
+Add `section` to the `[outputs]` block so Hugo generates `index.xml` for sections:
+
+```toml
+[outputs]
+  home = ["HTML", "RSS", "JSON"]
+  section = ["HTML", "RSS"]
+```
+
+### 2. Photography-specific RSS template (`layouts/photography/rss.xml`)
+
+Hugo resolves section-level RSS templates by looking for `layouts/{section}/rss.xml` before falling back to `layouts/_default/rss.xml`. The photography template:
+
+- Reuses the same channel metadata pattern as the default RSS template
+- Adds `xmlns:media` namespace for `<media:content>` tags
+- Each `<item>` includes:
+  - `<title>` — photo title
+  - `<description>` — photo description from front matter
+  - `<pubDate>` — publication date
+  - `<link>` / `<guid>` — permalink to the photo page
+  - `<enclosure>` — thumbnail image (300x300 webp) with URL, type, and length
+  - `<media:content>` — same thumbnail with width/height for richer feed reader support
+
+### 3. RSS icon on photography gallery page (`layouts/photography/baseof.html`)
+
+Add a small RSS icon link next to the "Photography" subtitle in the gallery header. The icon uses an inline SVG (standard RSS icon) styled to be subtle — low opacity, small size, matching the existing muted subtitle color.
+
+### 4. CSS for RSS icon (`assets/css/extended/custom.css`)
+
+Minimal styles for the RSS link:
+- Positioned inline next to the subtitle text
+- Small size (~14px), low opacity (0.4), slightly brighter on hover (0.7)
+- No border/underline to match the photography page's clean aesthetic
+
+## Test Plan
+
+- [ ] `hugo --minify` builds without errors
+- [ ] `/photography/index.xml` exists and is valid RSS XML
+- [ ] Feed items include `<enclosure>` tags with thumbnail URLs
+- [ ] Feed items include `<media:content>` tags
+- [ ] RSS icon appears on photography page, subtle and tasteful
+- [ ] RSS icon links to `/photography/index.xml`
+- [ ] Main site RSS at `/index.xml` still works and does NOT include photography pages
+- [ ] Blog section RSS at `/posts/index.xml` unaffected

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -1026,6 +1026,34 @@ hr {
     color: rgba(76, 129, 178, 0.9);
 }
 
+/* ===== Photography RSS link ===== */
+
+.photo-rss-link {
+    display: inline-flex;
+    align-items: center;
+    vertical-align: middle;
+    margin-left: 0.35rem;
+    color: rgba(255, 255, 255, 0.35);
+    border-bottom: none;
+    transition: color 0.15s linear;
+}
+
+.photo-rss-link:hover,
+.photo-rss-link:focus-visible {
+    color: rgba(255, 255, 255, 0.65);
+    border-bottom: none;
+}
+
+.photo-rss-link:visited {
+    color: rgba(255, 255, 255, 0.35);
+    border-bottom: none;
+}
+
+.photo-rss-link svg {
+    width: 14px;
+    height: 14px;
+}
+
 /* ===== Reduced motion ===== */
 
 @media (prefers-reduced-motion: reduce) {

--- a/hugo.toml
+++ b/hugo.toml
@@ -69,6 +69,7 @@ enableGitInfo = true
 
 [outputs]
   home = ["HTML", "RSS", "JSON"]
+  section = ["HTML", "RSS"]
 
 [taxonomies]
   tag = "tags"

--- a/layouts/photography/baseof.html
+++ b/layouts/photography/baseof.html
@@ -11,7 +11,7 @@
     <a href="#main-content" class="skip-link">Skip to content</a>
     <header class="photo-header">
         <h1 class="photo-header-title"><a href="/">Matt Walker</a></h1>
-        <p class="photo-header-subtitle">Photography</p>
+        <p class="photo-header-subtitle">Photography <a href="/photography/index.xml" class="photo-rss-link" title="Photography RSS Feed" aria-label="Subscribe to photography RSS feed"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="14" height="14"><circle cx="6.18" cy="17.82" r="2.18"/><path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83c0-8.59-6.97-15.56-15.56-15.56z"/><path d="M4 10.1v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"/></svg></a></p>
         <hr>
     </header>
 

--- a/layouts/photography/rss.xml
+++ b/layouts/photography/rss.xml
@@ -1,0 +1,63 @@
+{{- /* Photography RSS feed — includes <enclosure> and <media:content> for photo thumbnails */ -}}
+{{- $authorEmail := "" }}
+{{- $authorName := "" }}
+{{- with site.Params.author }}
+  {{- if reflect.IsMap . }}
+    {{- with .email }}
+      {{- $authorEmail = . }}
+    {{- end }}
+    {{- with .name }}
+      {{- $authorName = . }}
+    {{- end }}
+  {{- else }}
+    {{- $authorName = . }}
+  {{- end }}
+{{- end }}
+
+{{- $pages := .RegularPages }}
+{{- $limit := .Site.Config.Services.RSS.Limit }}
+{{- if ge $limit 1 }}
+{{- $pages = $pages | first $limit }}
+{{- end }}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0"
+     xmlns:atom="http://www.w3.org/2005/Atom"
+     xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>Photography on {{ .Site.Title }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>{{ with .Params.description }}{{ . }}{{ else }}Photography by {{ $authorName }}{{ end }}</description>
+    <generator>Hugo</generator>
+    <language>{{ site.Language.LanguageCode }}</language>
+    {{- with $authorEmail }}
+    <managingEditor>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</managingEditor>
+    {{- else }}{{ with $authorName }}
+    <managingEditor>{{ . }}</managingEditor>
+    {{- end }}{{ end }}
+    {{- with .Site.Copyright }}
+    <copyright>{{ . }}</copyright>
+    {{- end }}
+    {{- if not .Date.IsZero }}
+    <lastBuildDate>{{ (index $pages.ByLastmod.Reverse 0).Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+    {{- end }}
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range $pages }}
+    {{- $img := .Resources.GetMatch "*.{jpg,jpeg,png,webp}" }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{- with $authorEmail }}<author>{{ . }}{{ with $authorName }} ({{ . }}){{ end }}</author>{{ end }}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ with .Params.description }}{{ . | transform.XMLEscape | safeHTML }}{{ else }}{{ .Title | transform.XMLEscape | safeHTML }}{{ end }}</description>
+      {{- if $img }}
+      {{- $thumb := $img.Fill "300x300 webp q80" }}
+      <enclosure url="{{ $thumb.Permalink }}" length="{{ $thumb.Content | len }}" type="image/webp" />
+      <media:content url="{{ $thumb.Permalink }}" medium="image" type="image/webp" width="{{ $thumb.Width }}" height="{{ $thumb.Height }}" />
+      {{- end }}
+    </item>
+    {{- end }}
+  </channel>
+</rss>


### PR DESCRIPTION
## Summary

- Add a section-specific RSS feed at `/photography/index.xml` with `<enclosure>` and `<media:content>` tags containing 300x300 photo thumbnails for each gallery item
- Add a subtle RSS icon next to the "Photography" subtitle on the gallery page for feed discovery
- Enable RSS output for Hugo sections via `[outputs] section = ["HTML", "RSS"]` in hugo.toml

## Details

The photography RSS feed uses a custom template (`layouts/photography/rss.xml`) separate from the main blog feed, so subscribers can follow new photos without blog post noise. Each feed item includes:

- Photo title and description from front matter
- Publication date
- Link back to the photo's page
- `<enclosure>` tag with thumbnail URL, byte length, and MIME type
- `<media:content>` tag with thumbnail URL, width, height, and MIME type for richer feed reader support

The RSS icon on the gallery page uses an inline SVG styled at low opacity (0.35) to stay subtle and consistent with the existing muted aesthetic. It brightens slightly on hover.

## Test plan

- [x] `hugo --minify` builds without errors
- [x] `hugo server -D` runs without errors
- [x] `/photography/index.xml` exists and contains valid RSS with `<enclosure>` and `<media:content>` tags
- [x] RSS icon appears on photography gallery page, subtle and tasteful
- [x] RSS icon links to `/photography/index.xml`
- [x] Main site RSS at `/index.xml` still works and is unaffected
- [ ] Feed validates in an RSS validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)