### PR TITLE
chore: publish photography data posts

### DIFF
--- a/content/posts/2026-03_camera-gear-timeline.md
+++ b/content/posts/2026-03_camera-gear-timeline.md
@@ -1,6 +1,6 @@
 ---
 date: "2026-03-10"
-draft: true
+draft: false
 title: "Every Camera I've Ever Owned"
 slug: "camera-gear-timeline"
 description: "40 cameras, 24 phones, and a Kodak with a floppy disk — 22 years of photography gear traced through 94,000 photos of EXIF data."

--- a/content/posts/2026-03_photography-by-the-numbers.md
+++ b/content/posts/2026-03_photography-by-the-numbers.md
@@ -1,6 +1,6 @@
 ---
 date: "2026-03-10"
-draft: true
+draft: false
 title: "94,000 Photos by the Numbers"
 slug: "photography-by-the-numbers"
 description: "What 22 years of EXIF data reveals about when I shoot, what I shoot with, and how photography changed from film-era habits to phone-first instinct."


### PR DESCRIPTION
## Summary
- Remove `draft: true` from both photography EXIF data posts so they appear on the live site
- "Every Camera I've Ever Owned" and "94,000 Photos by the Numbers"

## Test plan
- [x] Both posts have `draft: false`
- [ ] Posts visible on live site after deploy

Generated with [Claude Code](https://claude.com/claude-code)