### PR TITLE
fix: increase category chart height for readability

### DIFF
--- a/.specs/052-category-chart-height.md
+++ b/.specs/052-category-chart-height.md
@@ -1,0 +1,16 @@
+# 052 — Increase category chart height
+
+## Summary
+
+The "Phone vs. dedicated camera" stacked bar chart in the camera gear timeline post is too short to read comfortably. Change the container aspect ratio from `5/2` (very wide and flat) to `5/4` (more square) so the chart is roughly 2.5x taller and the category breakdown is easier to interpret.
+
+## Changes
+
+- `content/posts/2026-03_camera-gear-timeline.md`: Change the `category-chart` container `aspect-ratio` from `5/2` to `5/4`
+
+## Test plan
+
+- [x] Category chart ("Phone vs. dedicated camera") renders visibly taller
+- [x] Timeline chart ("The timeline") is unaffected
+- [x] Sparkline histograms on camera cards are unaffected
+- [x] Chart remains responsive on narrow viewports

--- a/content/posts/2026-03_camera-gear-timeline.md
+++ b/content/posts/2026-03_camera-gear-timeline.md
@@ -36,7 +36,7 @@ The Pixel years run from 2016 to present. Google Pixel XL, 2 XL, 3 XL, 4 XL, 5, 
 
 ### Phone vs. dedicated camera
 
-<div style="position:relative;width:100%;aspect-ratio:5/2;margin:2rem 0;">
+<div style="position:relative;width:100%;aspect-ratio:5/4;margin:2rem 0;">
 <canvas id="category-chart"></canvas>
 </div>
 


### PR DESCRIPTION
## Summary
- The "Phone vs. dedicated camera" stacked bar chart was too short to read comfortably
- Changed the container aspect ratio from `5/2` (very wide/flat) to `5/4` (more square), making it ~2.5x taller

## Test plan
- [x] Category chart ("Phone vs. dedicated camera") renders visibly taller
- [x] Timeline chart ("The timeline") is unaffected
- [x] Sparkline histograms on camera cards are unaffected
- [x] Chart remains responsive on narrow viewports

Generated with [Claude Code](https://claude.com/claude-code)