### PR TITLE
feat: make timeline and category charts ~4x taller

### DIFF
--- a/content/posts/2026-03_camera-gear-timeline.md
+++ b/content/posts/2026-03_camera-gear-timeline.md
@@ -18,7 +18,7 @@ After [scanning 723GB of Google Takeout data](/posts/google-takeout-gallery-cura
 
 ### The timeline
 
-<div style="position:relative;width:100%;aspect-ratio:2/1;margin:2rem 0;">
+<div style="position:relative;width:100%;aspect-ratio:1/2;margin:2rem 0;">
 <canvas id="timeline-chart"></canvas>
 </div>
 
@@ -36,7 +36,7 @@ The Pixel years run from 2016 to present. Google Pixel XL, 2 XL, 3 XL, 4 XL, 5, 
 
 ### Phone vs. dedicated camera
 
-<div style="position:relative;width:100%;aspect-ratio:5/4;margin:2rem 0;">
+<div style="position:relative;width:100%;aspect-ratio:5/16;margin:2rem 0;">
 <canvas id="category-chart"></canvas>
 </div>
 


### PR DESCRIPTION
## Summary
- Timeline chart: aspect-ratio 2/1 → 1/2 (~4x taller)
- Phone vs. dedicated camera chart: aspect-ratio 5/4 → 5/16 (~4x taller)

## Test plan
- [ ] Charts render at increased height on desktop and mobile

Generated with [Claude Code](https://claude.com/claude-code)