### PR TITLE
fix: resolve Bing SEO issues

### DIFF
--- a/.specs/058-bing-seo-fixes.md
+++ b/.specs/058-bing-seo-fixes.md
@@ -1,0 +1,32 @@
+# 058: Bing SEO Fixes
+
+**Branch**: `feature/bing-seo-fixes`
+**Created**: 2026-03-12
+
+## Summary
+
+Fix SEO issues flagged by Bing Webmaster Tools: multiple h1 tags per page, missing/short meta descriptions on two photography pages, and identical meta descriptions on taxonomy (tag) pages.
+
+## Requirements
+
+- Fix double h1 tags: site title in header should be `<span>`, not `<h1>`, on interior pages
+- Add proper title, alt, and description to 2 incomplete photography pages
+- Generate unique meta descriptions for taxonomy pages instead of falling back to site description
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `layouts/partials/header.html` | Change site title from `<h1>` to `<span>` |
+| `layouts/photography/baseof.html` | Change site title from `<h1>` to `<span>` |
+| `content/photography/2025-06-18-photo-mm30fzuo/index.md` | Add title, alt, description |
+| `content/photography/2025-08-15-photo-mm30excl/index.md` | Add title, alt, description |
+| `layouts/partials/extend_head.html` | Add unique meta description override for taxonomy pages |
+
+## Test Plan
+
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [x] No pages have multiple h1 tags (verified: 1 h1 per post page)
+- [x] Both photo pages have proper meta descriptions
+- [x] Tag pages have unique meta descriptions (includes post count and sample titles)
+- [ ] Site renders correctly on localhost (`hugo server -D`)

--- a/content/photography/2025-06-18-photo-mm30fzuo/index.md
+++ b/content/photography/2025-06-18-photo-mm30fzuo/index.md
@@ -1,5 +1,7 @@
 ---
-title: "Photo 2025-06-18"
+title: "Mulch Mushroom Bloom"
 date: "2025-06-18"
+alt: "Dozens of tiny mushrooms sprouting from dark mulch ground cover, with a green lawn and brick house visible in the background"
+description: "A carpet of delicate mushrooms emerges from the mulch after summer rain, their thin stems and small caps dotting the ground beneath the trees."
 draft: false
 ---

--- a/content/photography/2025-08-15-photo-mm30excl/index.md
+++ b/content/photography/2025-08-15-photo-mm30excl/index.md
@@ -1,5 +1,7 @@
 ---
-title: "Photo 2025-08-15"
+title: "Superhot Peppers Ripening"
 date: "2025-08-15"
+alt: "Red superhot peppers ripening on the plant among lush green leaves in a backyard garden"
+description: "Superhot peppers turning red on the vine in the summer garden — wrinkled skins and vivid color signaling they're almost ready to pick."
 draft: false
 ---

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,3 +1,13 @@
+{{- /* Unique meta descriptions for tag/category term pages */ -}}
+{{- if eq .Kind "term" -}}
+{{- $count := len .Pages -}}
+{{- $sample := slice -}}
+{{- range first 3 .Pages -}}
+  {{- $sample = $sample | append .Title -}}
+{{- end -}}
+<meta name="description" content="Browse {{ $count }} post{{ if ne $count 1 }}s{{ end }} tagged &quot;{{ .Title }}&quot; on {{ site.Title }}'s site{{ with $sample }}, including {{ delimit . ", " }}{{ end }}." />
+{{- end -}}
+
 {{- /* Preload avatar on homepage for faster LCP */ -}}
 {{- if .IsHome }}
 {{- $avatar := resources.Get "images/MattWalker-avatar.png" }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -27,7 +27,7 @@
     <nav class="nav">
         <div class="logo">
             <a href="{{ "" | absLangURL }}" accesskey="h" aria-label="Home Page">
-                <h1 class="site-title">{{ site.Title }}</h1>
+                <span class="site-title">{{ site.Title }}</span>
             </a>
         </div>
     </nav>

--- a/layouts/photography/baseof.html
+++ b/layouts/photography/baseof.html
@@ -10,7 +10,7 @@
 
     <a href="#main-content" class="skip-link">Skip to content</a>
     <header class="photo-header">
-        <h1 class="photo-header-title"><a href="/">Matt Walker</a></h1>
+        <span class="photo-header-title"><a href="/">Matt Walker</a></span>
         <p class="photo-header-subtitle">Photography <a href="/photography/index.xml" class="photo-rss-link" title="Photography RSS Feed" aria-label="Subscribe to photography RSS feed"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="14" height="14"><circle cx="6.18" cy="17.82" r="2.18"/><path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83c0-8.59-6.97-15.56-15.56-15.56z"/><path d="M4 10.1v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"/></svg></a></p>
         <hr>
     </header>


### PR DESCRIPTION
## Summary
- Fix double h1 tags: site title in header changed from `<h1>` to `<span>` on both main and photography layouts
- Add proper title, alt, and description to 2 incomplete photography pages (mushroom bloom, superhot peppers)
- Generate unique meta descriptions for taxonomy term pages (includes post count and sample titles)

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [x] No pages have multiple h1 tags (verified: 1 h1 per post page)
- [x] Both photo pages have proper meta descriptions
- [x] Tag pages have unique meta descriptions (includes post count and sample titles)
- [ ] Site renders correctly on localhost (`hugo server -D`)

Generated with [Claude Code](https://claude.com/claude-code)