### PR TITLE
fix: expand short meta descriptions to recommended length

### DIFF
--- a/.specs/060-meta-descriptions.md
+++ b/.specs/060-meta-descriptions.md
@@ -1,0 +1,25 @@
+# 060: Expand Short Meta Descriptions
+
+**Branch**: `feature/meta-descriptions`
+**Created**: 2026-03-12
+
+## Summary
+
+Expand 6 blog post meta descriptions from under 120 characters to the 120-160 character range recommended by Bing Webmaster Tools. Longer descriptions improve search result snippets and click-through rates.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `content/posts/2009-02_mind-control.md` | Expand description from 63 to ~131 chars |
+| `content/posts/2017-01_2016-looking-back.md` | Expand description from 74 to ~142 chars |
+| `content/posts/2026-02_website-update-2026.md` | Expand description from 83 to ~150 chars |
+| `content/posts/2026-03_the-membrane.md` | Expand description from 89 to ~148 chars |
+| `content/posts/2009-03_freedom-of-the-seas.md` | Expand description from 92 to ~145 chars |
+| `content/posts/2008-04_happy-earth-day.md` | Expand description from 94 to ~142 chars |
+
+## Test Plan
+
+- [x] Hugo builds with no errors (`hugo --minify`)
+- [x] All 6 updated descriptions are between 120-160 characters
+- [ ] Site renders correctly on localhost (`hugo server -D`)

--- a/content/posts/2008-04_happy-earth-day.md
+++ b/content/posts/2008-04_happy-earth-day.md
@@ -3,7 +3,7 @@ date: "2008-04-22"
 draft: false
 title: "Happy Earth Day"
 slug: "happy-earth-day"
-description: "The irony of spotting a Hummer on Earth Day — a quick photo taken at lunch that says it all."
+description: "The irony of spotting a Hummer parked front and center on Earth Day — a quick photo snapped at lunch that perfectly captures the contradiction."
 aliases:
   - /happy-earth-day/
 ---

--- a/content/posts/2009-02_mind-control.md
+++ b/content/posts/2009-02_mind-control.md
@@ -3,7 +3,7 @@ date: "2009-02-13"
 draft: false
 title: "Mind Control - Tea in 30 Seconds"
 slug: "mind-control"
-description: "A fun time-lapse video of making tea condensed into 30 seconds."
+description: "A fun time-lapse video of making a cup of tea condensed into 30 seconds — from boiling the kettle to the first sip, at high speed."
 aliases:
   - /mind-control/
 ---

--- a/content/posts/2009-03_freedom-of-the-seas.md
+++ b/content/posts/2009-03_freedom-of-the-seas.md
@@ -3,7 +3,7 @@ date: "2009-03-26"
 draft: false
 title: "Cruising the Caribbean - Freedom of the Seas"
 slug: "freedom-of-the-seas"
-description: "Video highlights from our Caribbean cruise on Royal Caribbean's Freedom of the Seas in 2009."
+description: "Video highlights from our Caribbean cruise aboard Royal Caribbean's Freedom of the Seas — sun, ports, and ocean views from a week at sea in 2009."
 aliases:
   - /freedom-of-the-seas/
 tags:

--- a/content/posts/2017-01_2016-looking-back.md
+++ b/content/posts/2017-01_2016-looking-back.md
@@ -3,7 +3,7 @@ date: "2017-01-01"
 draft: false
 title: "Looking Back on 2016"
 slug: "2016-looking-back"
-description: "Looking back on 2016, it was a good year.  Here are some of my highlights."
+description: "A look back at 2016 — homeschooling milestones, a record largemouth bass at Liberty Reservoir, government open-source work with 18F, and more."
 cover:
   image: "/img/LibertyBass.jpg"
   alt: "Personal best largemouth bass caught at Liberty Reservoir"

--- a/content/posts/2026-02_website-update-2026.md
+++ b/content/posts/2026-02_website-update-2026.md
@@ -3,7 +3,7 @@ date: "2026-02-19"
 draft: false
 title: "Version 2026 (Hugo > Hugo, but better)"
 slug: "website-update-2026"
-description: "Nine years later, the site gets a proper rebuild. Same engine, new everything else."
+description: "Nine years later, mrmatt.io gets a proper rebuild. Same Hugo engine, but Cloudflare Pages, GitHub Actions, PaperMod theme, and zero npm dependencies."
 summary: "Nine years later, the site gets a proper rebuild. Same engine, new everything else."
 cover:
   image: "/images/mrmatt-io-hugo-v1.png"

--- a/content/posts/2026-03_the-membrane.md
+++ b/content/posts/2026-03_the-membrane.md
@@ -3,7 +3,7 @@ date: "2026-03-11"
 draft: false
 title: "The Membrane"
 slug: "the-membrane"
-description: "The AI capability boundary is expanding. So is the surface area where humans matter most."
+description: "The AI capability boundary is expanding — and so is the surface area where humans matter most. A mental model for navigating the human-AI interface."
 summary: "The AI capability boundary is expanding. So is the surface area where humans matter most."
 images:
   - "/images/the-membrane-og.png"


### PR DESCRIPTION
## Summary
- Expand 6 blog post meta descriptions from under 120 characters to the 120-160 character range recommended by Bing Webmaster Tools
- Longer descriptions improve search result snippets and click-through rates

## Test plan
- [x] Hugo builds with no errors (`hugo --minify`)
- [x] All 6 updated descriptions are between 120-160 characters
- [ ] Site renders correctly on localhost (`hugo server -D`)

Generated with [Claude Code](https://claude.com/claude-code)