### PR TITLE
fix: remove photo thumbnail attrs that broke grid layout

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -58,7 +58,7 @@
                 <img src="{{ $thumb300.RelPermalink }}"
                      srcset="{{ $thumb200.RelPermalink }} 200w, {{ $thumb300.RelPermalink }} 300w"
                      sizes="(max-width: 549px) calc(25vw - 0.5rem), 10em"
-                     alt="{{ with .Params.alt }}{{ . }}{{ else }}{{ .Title }}{{ end }}" class="photo-thumb" width="300" height="300" loading="lazy" />
+                     alt="{{ with .Params.alt }}{{ . }}{{ else }}{{ .Title }}{{ end }}" class="photo-thumb" loading="lazy" />
                 </div>
             </a>
             {{- end }}


### PR DESCRIPTION
## Summary
- Removes `width="300" height="300"` HTML attributes from homepage photo strip thumbnails
- These attributes (added in #5369 for CLS) caused CSS Grid items to use 300px as their minimum intrinsic size, rendering thumbnails oversized and zoomed-in
- The existing CSS (`width: 100%; aspect-ratio: 1; object-fit: cover`) handles sizing correctly without the attributes

## Test plan
- [x] Homepage photo thumbnails render at correct size (not oversized/zoomed)
- [x] Photo grid maintains 4-column layout on desktop
- [x] Hugo builds with no errors (`hugo --minify`)
- [x] Site renders correctly on localhost (`hugo server -D`)

Generated with [Claude Code](https://claude.com/claude-code)