### PR TITLE
fix: resolve Lighthouse audit issues

### DIFF
--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -12,8 +12,6 @@
 <meta name="color-scheme" content="light dark">
 <meta name="referrer" content="no-referrer-when-downgrade">
 <meta name="format-detection" content="telephone=no">
-<meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
-<meta http-equiv="X-Content-Type-Options" content="nosniff">
 <meta name="robots" content="max-image-preview:large">
 <meta name="mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-capable" content="yes">

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+{{- if hugo.IsProduction | or (eq site.Params.env "production") }}
+Allow: /
+{{- else }}
+Disallow: /
+{{- end }}
+
+Sitemap: {{ "sitemap.xml" | absURL }}

--- a/layouts/shortcodes/figure-img.html
+++ b/layouts/shortcodes/figure-img.html
@@ -1,0 +1,21 @@
+{{- $src := .Get "src" -}}
+{{- $alt := .Get "alt" | default "" -}}
+{{- $caption := .Get "caption" | default "" -}}
+{{- $loading := .Get "loading" | default "lazy" -}}
+{{- $img := resources.Get $src -}}
+{{- if $img -}}
+{{- $webp := $img.Process "resize 1536x webp q80" -}}
+<figure class="post-figure">
+  <img
+    src="{{ $webp.RelPermalink }}"
+    alt="{{ $alt }}"
+    width="{{ $webp.Width }}"
+    height="{{ $webp.Height }}"
+    loading="{{ $loading }}"
+    decoding="async"
+  />
+  {{- with $caption }}
+  <figcaption>{{ . }}</figcaption>
+  {{- end }}
+</figure>
+{{- end -}}

--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,3 @@
+/*
+  X-Content-Type-Options: nosniff
+  Permissions-Policy: camera=(), microphone=(), geolocation=()


### PR DESCRIPTION
## Summary
- Override theme robots.txt with `Allow: /` instead of empty `Disallow:` that validators flag as invalid
- Remove invalid `<meta http-equiv="Permissions-Policy">` and `<meta http-equiv="X-Content-Type-Options">` that cause browser console errors; serve as proper HTTP headers via Cloudflare Pages `_headers` file
- Add `figure-img` shortcode for processing images through Hugo's pipeline (WebP conversion with width/height)

## Test plan
- [ ] `robots.txt` passes validation (no errors in Lighthouse)
- [ ] No browser console errors from invalid meta tags
- [ ] Cloudflare Pages serves `X-Content-Type-Options` and `Permissions-Policy` as HTTP headers
- [ ] `figure-img` shortcode renders images as WebP with dimensions

Generated with [Claude Code](https://claude.com/claude-code)