### PR TITLE
fix: increase chart aspect ratios for data visualization impact

### DIFF
--- a/.specs/064-taller-charts.md
+++ b/.specs/064-taller-charts.md
@@ -1,0 +1,48 @@
+# 064: Taller Chart Aspect Ratios Across All Posts
+
+**Branch**: `feature/taller-charts`
+**Created**: 2026-03-16
+
+## Summary
+
+Charts across all three data-visualization posts are vertically compressed, making them less impactful. This sweep updates CSS aspect ratios on all chart containers to give them more vertical space, making the data easier to read and more visually striking.
+
+## Requirements
+
+- Increase vertical height of all `5/2` (2.5:1) aspect-ratio chart containers — these are the most compressed
+- Increase vertical height of `4/3` grid chart containers
+- Increase vertical height of `2/1` chart containers
+- Leave already-tall charts alone (`1/1` timeline, `5/6` category in camera gear post)
+- Leave custom canvas elements (heatmap, sparklines) unchanged
+- No changes to Chart.js config — only CSS container aspect ratios
+
+## Design
+
+All charts use the same pattern: a `<div>` wrapper with inline `style="... aspect-ratio:X/Y ..."` containing a `<canvas>`. Chart.js has `maintainAspectRatio: false` so it fills whatever container size CSS gives it. We only need to change the `aspect-ratio` values in the inline styles.
+
+**New aspect ratios:**
+
+| Old ratio | New ratio | Context |
+|-----------|-----------|---------|
+| `5/2` (2.5:1) | `16/9` (~1.78:1) | Full-width charts — ~40% taller |
+| `4/3` (1.33:1) | `1/1` (1:1) | Grid charts — 33% taller, square |
+| `2/1` (2:1) | `3/2` (1.5:1) | Top wins horizontal bar — 33% taller |
+| `1/1` | `1/1` | No change (camera timeline) |
+| `5/6` | `5/6` | No change (camera category) |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `content/posts/2026-03_autoresearch-webperf.md` | Update aspect ratios on 7 chart containers |
+| `content/posts/2026-03_photography-by-the-numbers.md` | Update aspect ratios on 11 chart containers + heatmap |
+| `content/posts/2026-03_camera-gear-timeline.md` | No changes needed (already 1/1 and 5/6) |
+
+## Test Plan
+
+- [ ] Hugo builds with no errors (`hugo --minify`)
+- [ ] Site renders correctly on localhost (`hugo server -D`)
+- [ ] Autoresearch post: all 7 charts render taller, no overflow or clipping
+- [ ] Photography post: all 11 charts + heatmap render taller, grid layouts still work
+- [ ] Camera gear timeline post: unchanged, still renders correctly
+- [ ] Charts remain responsive on narrow viewports

--- a/content/posts/2026-03_autoresearch-webperf.md
+++ b/content/posts/2026-03_autoresearch-webperf.md
@@ -42,7 +42,7 @@ The agent was allowed to modify eight files: `extend_head.html` (resource hints)
 
 ### LCP over 200 experiments
 
-<div style="position:relative; width:100%; aspect-ratio:5/2; margin:2rem 0;">
+<div style="position:relative; width:100%; aspect-ratio:16/9; margin:2rem 0;">
 <canvas id="lcp-timeline"></canvas>
 </div>
 
@@ -53,10 +53,10 @@ Baseline was 2,638ms. The agent got it to a stable 2,109ms -- a **20% reduction*
 ### Experiment outcomes
 
 <div style="display:grid; grid-template-columns:1fr 1fr; gap:1.5rem; margin:2rem 0;">
-<div style="position:relative; width:100%; aspect-ratio:4/3;">
+<div style="position:relative; width:100%; aspect-ratio:1/1;">
 <canvas id="outcomes-chart"></canvas>
 </div>
-<div style="position:relative; width:100%; aspect-ratio:4/3;">
+<div style="position:relative; width:100%; aspect-ratio:1/1;">
 <canvas id="category-chart"></canvas>
 </div>
 </div>
@@ -65,7 +65,7 @@ Of 200 experiments, 147 were kept (74%) and 47 discarded (23%). Four crashed the
 
 ### What actually moved the needle
 
-<div style="position:relative; width:100%; aspect-ratio:2/1; margin:2rem 0;">
+<div style="position:relative; width:100%; aspect-ratio:3/2; margin:2rem 0;">
 <canvas id="top-wins"></canvas>
 </div>
 
@@ -77,7 +77,7 @@ Image quality reduction (q80 → q60 on thumbnails) and matching the preload to 
 
 ### The surprise: preloads can hurt
 
-<div style="position:relative; width:100%; aspect-ratio:5/2; margin:2rem 0;">
+<div style="position:relative; width:100%; aspect-ratio:16/9; margin:2rem 0;">
 <canvas id="preload-chart"></canvas>
 </div>
 
@@ -87,7 +87,7 @@ On a throttled 4G connection, every preload competes for the same limited bandwi
 
 ### Build size vs. LCP
 
-<div style="position:relative; width:100%; aspect-ratio:5/2; margin:2rem 0;">
+<div style="position:relative; width:100%; aspect-ratio:16/9; margin:2rem 0;">
 <canvas id="size-chart"></canvas>
 </div>
 
@@ -95,7 +95,7 @@ Build size and LCP had almost no correlation. The site grew from ~700MB to ~949M
 
 ### The noise problem
 
-<div style="position:relative; width:100%; aspect-ratio:5/2; margin:2rem 0;">
+<div style="position:relative; width:100%; aspect-ratio:16/9; margin:2rem 0;">
 <canvas id="noise-chart"></canvas>
 </div>
 

--- a/content/posts/2026-03_photography-by-the-numbers.md
+++ b/content/posts/2026-03_photography-by-the-numbers.md
@@ -15,7 +15,7 @@ I scanned the EXIF headers of every JPEG across 15 Google Takeout zip files. Her
 
 ### Volume over time
 
-<div style="position:relative; width:100%; aspect-ratio:5/2; margin:2rem 0;">
+<div style="position:relative; width:100%; aspect-ratio:16/9; margin:2rem 0;">
 <canvas id="yearly-chart"></canvas>
 </div>
 
@@ -24,10 +24,10 @@ The yearly photo count forms a bell curve peaking at 2015 with 13,816 photos. Th
 ### When I shoot
 
 <div style="display:grid; grid-template-columns:1fr 1fr; gap:1.5rem; margin:2rem 0;">
-<div style="position:relative; width:100%; aspect-ratio:4/3;">
+<div style="position:relative; width:100%; aspect-ratio:1/1;">
 <canvas id="hourly-chart"></canvas>
 </div>
-<div style="position:relative; width:100%; aspect-ratio:4/3;">
+<div style="position:relative; width:100%; aspect-ratio:1/1;">
 <canvas id="dow-chart"></canvas>
 </div>
 </div>
@@ -36,7 +36,7 @@ Saturday at 10am is my golden hour. Weekends get twice the shooting volume of mi
 
 ### The heatmap
 
-<div style="position:relative; width:100%; aspect-ratio:5/2; margin:2rem 0;">
+<div style="position:relative; width:100%; aspect-ratio:16/9; margin:2rem 0;">
 <canvas id="heatmap-chart"></canvas>
 </div>
 
@@ -44,7 +44,7 @@ The pattern is clear: weekend mornings and afternoons are when I reach for the c
 
 ### People in photos
 
-<div style="position:relative; width:100%; aspect-ratio:5/2; margin:2rem 0;">
+<div style="position:relative; width:100%; aspect-ratio:16/9; margin:2rem 0;">
 <canvas id="people-chart"></canvas>
 </div>
 
@@ -52,7 +52,7 @@ The percentage of photos containing people dropped from 70% in 2016 to under 2% 
 
 ### Where in the world
 
-<div style="position:relative; width:100%; aspect-ratio:5/2; margin:2rem 0;">
+<div style="position:relative; width:100%; aspect-ratio:16/9; margin:2rem 0;">
 <canvas id="gps-chart"></canvas>
 </div>
 
@@ -61,13 +61,13 @@ GPS data went from 0% in the pre-smartphone era to 91% in 2017, then drifted bac
 ### The lens settings
 
 <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:1.5rem; margin:2rem 0;">
-<div style="position:relative; width:100%; aspect-ratio:4/3;">
+<div style="position:relative; width:100%; aspect-ratio:1/1;">
 <canvas id="aperture-chart"></canvas>
 </div>
-<div style="position:relative; width:100%; aspect-ratio:4/3;">
+<div style="position:relative; width:100%; aspect-ratio:1/1;">
 <canvas id="focal-chart"></canvas>
 </div>
-<div style="position:relative; width:100%; aspect-ratio:4/3;">
+<div style="position:relative; width:100%; aspect-ratio:1/1;">
 <canvas id="iso-time-chart"></canvas>
 </div>
 </div>
@@ -77,10 +77,10 @@ f/2.0 at 27mm. That's the phone sweet spot -- a moderately wide angle with a fas
 ### Resolution and exposure
 
 <div style="display:grid; grid-template-columns:1fr 1fr; gap:1.5rem; margin:2rem 0;">
-<div style="position:relative; width:100%; aspect-ratio:4/3;">
+<div style="position:relative; width:100%; aspect-ratio:1/1;">
 <canvas id="resolution-chart"></canvas>
 </div>
-<div style="position:relative; width:100%; aspect-ratio:4/3;">
+<div style="position:relative; width:100%; aspect-ratio:1/1;">
 <canvas id="exposure-chart"></canvas>
 </div>
 </div>
@@ -89,7 +89,7 @@ Resolution plateaued after the megapixel race ended. The jump from 4MP in 2003 t
 
 ### The full heartbeat
 
-<div style="position:relative; width:100%; aspect-ratio:5/2; margin:2rem 0;">
+<div style="position:relative; width:100%; aspect-ratio:16/9; margin:2rem 0;">
 <canvas id="monthly-chart"></canvas>
 </div>
 


### PR DESCRIPTION
## Summary
- Charts across autoresearch and photography posts were vertically compressed (5/2 aspect ratio = 2.5x wider than tall)
- Updated full-width charts from `5/2` → `16/9` (~40% taller)
- Updated grid charts from `4/3` → `1/1` (square, 33% taller)
- Updated horizontal bar from `2/1` → `3/2` (33% taller)
- Camera gear timeline post already had correct sizing (1/1 and 5/6) — no changes needed

## Test plan
- [ ] Hugo builds with no errors (`hugo --minify`)
- [ ] Site renders correctly on localhost (`hugo server -D`)
- [ ] Autoresearch post: all 7 charts render taller, no overflow or clipping
- [ ] Photography post: all 11 charts + heatmap render taller, grid layouts still work
- [ ] Camera gear timeline post: unchanged, still renders correctly
- [ ] Charts remain responsive on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)