### PR TITLE
feat: add writing and illustration style guides

### DIFF
--- a/.specs/065-style-guides.md
+++ b/.specs/065-style-guides.md
@@ -1,0 +1,53 @@
+# 065: Writing & Illustration Style Guides
+
+**Branch**: `feat/style-guides`
+**Created**: 2026-03-16
+
+## Summary
+
+Create two style reference documents that capture Matt's personal writing voice and the site's editorial illustration style. These guides serve as references for AI-assisted content creation, ensuring future blog posts sound like Matt and future illustrations maintain visual consistency.
+
+## Motivation
+
+As AI-assisted writing becomes a regular part of the blog workflow, it's important to have a codified reference for Matt's actual voice. Analysis of the 2007–2017 corpus revealed clear differences between human-written and AI-written posts (ellipses vs em dashes, casual imperfection vs polished parallelism, playful humor vs restrained self-awareness). The writing guide captures what makes Matt's voice distinctive so AI tools can match it.
+
+Similarly, the pen-and-ink editorial illustrations from the "Membrane" and "Autoresearch" posts established a visual language worth preserving across future posts.
+
+## Requirements
+
+- [x] `WRITING-STYLE.md` at repo root — comprehensive writing style guide covering:
+  - Voice and tone
+  - Sentence structure patterns
+  - Punctuation habits (especially the ellipsis as signature mark, and avoidance of em dashes)
+  - Vocabulary (colloquialisms Matt uses, words to avoid)
+  - Recurring verbal patterns and openers/closers
+  - Formatting conventions
+  - Content structure templates by post type
+  - The "imperfection factor" — how Matt's posts differ from AI polish
+- [x] `ILLUSTRATION-STYLE.md` at repo root — illustration style guide covering:
+  - Medium (monochrome pen-and-ink)
+  - Technique (cross-hatching, stippling)
+  - Compositional elements (small human figure, conceptual metaphors, labels)
+  - Tone (technical but approachable, editorial not corporate)
+  - Image specifications (format, size, naming)
+  - Reference illustrations with descriptions
+- [x] Spec file at `.specs/064-style-guides.md`
+
+## Source Analysis
+
+The writing style guide was derived from close reading of all human-written posts (2007–2017 plus the 2026 website update), excluding the AI-written 2026-03 series. Key differentiators identified:
+
+1. Matt uses ellipses (...) where AI uses em dashes (—)
+2. Matt's sentences are loose and varied; AI writes careful parallelism
+3. Matt's posts have typos and comma splices; AI posts are immaculate
+4. Matt's sections are unevenly sized; AI sections are perfectly balanced
+5. Matt uses words like "sweet," "stout," "floored"; AI uses "durable," "converge," "orchestrating"
+6. Matt ends with "More to follow..." or "I am quite happy."; AI ends with thematic callbacks
+
+The illustration style guide was derived from the two editorial illustrations: `ai-capability-membrane-model.png` and `ai-experiment-rig.png`.
+
+## Test Plan
+
+- [ ] Both files render correctly on GitHub
+- [ ] Writing guide is referenced in future blog post workflows
+- [ ] Illustration guide is referenced when creating new post illustrations

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,11 @@ hugo.toml
 - Branch: `v2026` is the working branch for the rebuild
 - Base/main branch: `master` (will rename to `main` at ship time)
 
+## Style Guides
+
+- **Writing style:** See `WRITING-STYLE.md` — Matt's voice, tone, punctuation habits, and post structure patterns. Reference this when drafting or editing any blog post.
+- **Illustration style:** See `ILLUSTRATION-STYLE.md` — monochrome pen-and-ink editorial illustration style. Reference this when creating hero images or conceptual diagrams.
+
 ## Content Notes
 
 - Old content uses `+++` TOML front matter — migrate to `---` YAML front matter for PaperMod

--- a/ILLUSTRATION-STYLE.md
+++ b/ILLUSTRATION-STYLE.md
@@ -1,0 +1,76 @@
+# MrMatt.io — Illustration Style Guide
+
+This guide captures the visual style established by the editorial illustrations on mrmatt.io, starting with the "Membrane" and "Autoresearch" blog posts. Use it as a reference when commissioning or generating illustrations for future posts.
+
+---
+
+## Style Summary
+
+**Monochrome pen-and-ink editorial illustration** — hand-drawn, conceptual, and approachable. Think magazine feature illustration or conference talk visual, not corporate infographic or stock art.
+
+## Medium and Technique
+
+- **Black and white only** — no color, no grayscale fills. All tone comes from line work.
+- **Cross-hatching and stippling** for shading, depth, and texture. This gives the illustrations their hand-sketched, editorial quality.
+- **Clean outlines** with varying line weight — heavier for foreground elements, lighter for detail.
+- **White background** — no border, no frame, no colored backdrop. The illustration floats on the page.
+
+## Compositional Elements
+
+### The Human Figure
+Every illustration includes a **small-scale human figure** as an observer or participant:
+- Simply drawn but recognizable — not a stick figure, but not detailed either
+- Consistent proportions across illustrations (about 5–6 heads tall)
+- Usually positioned at the edge of the composition, looking in at the system
+- Wearing simple, everyday clothing (t-shirt, pants)
+- The figure provides **scale contrast** — the human is small relative to the system or concept being depicted
+
+### Conceptual Metaphors
+The illustrations use **physical/mechanical metaphors to explain abstract ideas**:
+- A factory conveyor belt for an automated experiment loop
+- A biological cell with a membrane for an AI capability boundary
+- The metaphor should be immediately understandable without reading the caption
+
+### Labels and Annotations
+- **Clean, sans-serif text labels** placed directly on or near elements
+- Connected by arrows or callout lines where needed
+- Labels are descriptive but brief (one or two words)
+- Boxed labels for key concepts (e.g., "Innovation," "The Membrane")
+- Labels are part of the composition, not overlaid as an afterthought
+
+## Tone and Feel
+
+- **Technical but approachable** — explains complex ideas without being intimidating
+- **Whimsical but not cartoonish** — has personality and warmth, not cold or clinical
+- **Editorial, not corporate** — the kind of illustration you'd see in a thoughtful long-form article, not a marketing deck
+- **Hand-drawn character** — should feel like someone sat down with pen and ink, even if generated digitally. Slight imperfections are a feature.
+
+## What to Avoid
+
+- Color (beyond black/white)
+- Photorealistic rendering
+- Corporate flat illustration style (the "tech company blog" look)
+- Overly complex scenes with too many elements
+- Clip art or icon-based compositions
+- 3D rendering or gradients
+- Decorative borders or frames
+
+## Image Specifications
+
+- **Format:** PNG with transparent or white background
+- **Source size:** High resolution (at least 2000px wide) — Hugo will process down to WebP at 1536px
+- **Aspect ratio:** Landscape or wide (roughly 16:9 to 2:1) for hero/feature images
+- **File naming:** `descriptive-slug.png` in `assets/images/`
+- **Alt text:** Always descriptive of the conceptual content, not just the visual elements
+
+## Reference Illustrations
+
+### "The Membrane" (`ai-capability-membrane-model.png`)
+A biological cell labeled "AI" with a textured membrane boundary. A pseudopod pushes outward toward "Innovation." A small human figure stands outside observing. Heavy cross-hatching on the cell interior, stippling on the membrane.
+
+### "Autoresearch Experiment Rig" (`ai-experiment-rig.png`)
+A factory conveyor belt with stages: Modify → Build → Measure → DOM hash → Keep/Discard. Gears and mechanical details. A small human figure holds a clipboard on the left. A large curved "REPEAT" arrow wraps around the bottom. Industrial/workshop feel.
+
+---
+
+*This style guide was established with illustrations created for the March 2026 blog posts and represents the visual language of mrmatt.io editorial content going forward.*

--- a/WRITING-STYLE.md
+++ b/WRITING-STYLE.md
@@ -1,0 +1,164 @@
+# Matt Walker — Writing Style Guide
+
+This guide captures the voice, tone, and writing patterns from Matt's blog posts (2007–2017 and the 2026 website update). Use it as a reference when drafting or editing blog posts so they read like Matt wrote them, not an AI.
+
+---
+
+## Voice and Tone
+
+Matt writes like he's talking to a friend who happens to be interested in the same stuff. The register is **casual-conversational** — never formal, never sloppy. He's genuinely enthusiastic about the things he writes about, and that comes through without trying too hard.
+
+**Key characteristics:**
+
+- **Genuine enthusiasm** — Matt doesn't hedge when he likes something. "Without a doubt the best toy for the price." / "I was floored." / "This thing is amazing!"
+- **Self-deprecating humor** — He'll joke about destroying his camera, locking himself out of his own encrypted drive, or the tiny audience for his site. "the handful of people who stumble across it"
+- **Playful and spontaneous** — Invents acronyms ("HSWS — Honda Slow Window Syndrome"), hides JavaScript pranks in links, uses stretched spelling ("waaayyy up there")
+- **Honest about limitations** — "Nothing scientific here... just 'click of the mouse' impressions." / "Don't ask me how the thing works."
+- **Constructive, never mean** — Even negative reviews stay constructive: "My only gripe is..." or "Not a big deal, but..."
+- **Cost-conscious** — Frequently mentions prices, compares costs, notes when something is a good deal vs overpriced
+
+## Sentence Structure
+
+- **Short to medium sentences** (10–20 words typical). Occasionally longer when telling a story, but rarely past one compound clause.
+- **Fragments for emphasis** — "Boo." / "Welcome." / "Duh!" / "This is a classic..."
+- **Loose compound sentences** joined by "but" or "and" — sometimes comma splices that feel natural: "I followed it to the ground and watched it bounce about 20 feet back into the air."
+- **No overly parallel constructions.** Sentences vary in length and rhythm. Avoid the AI pattern of three perfectly balanced clauses.
+
+## Punctuation
+
+### Ellipsis (...) — Matt's Signature
+
+The ellipsis is Matt's most distinctive punctuation mark. It does a lot of work:
+
+- **Trailing thoughts:** "More to follow..." / "Stay tuned..."
+- **Dramatic pauses:** "So... I figured I would try"
+- **Self-interruption:** "Don't ask me why... it just isn't socially acceptable"
+- **Building suspense:** "when I saw this movie in the theater this past fall..."
+- **Comedic timing:** "well... portable"
+
+### What NOT to use
+
+- **Em dashes (—)** — Matt almost never uses them in his own writing. This is one of the biggest tells that something was AI-written. Use ellipses or parentheses instead.
+- **Semicolons** — Used occasionally but inconsistently. Don't go out of your way to include them.
+
+### Other punctuation
+
+- **Exclamation marks** — Used for genuine excitement, never ironic: "Life after Lasik!" / "This thing is amazing!"
+- **Parenthetical asides** — Very frequent and conversational: "(don't ask)", "(yet)", "(not my parent's station wagon)"
+- **Oxford comma** — Not consistently used. Tends to omit: "cars, robots, computers now planes"
+- **Colons** — Used to introduce things: "Just think:" / "Here is how it works:"
+
+## Vocabulary and Word Choice
+
+### Colloquialisms Matt Actually Uses
+
+- "a ton of fun" / "a bunch of fun"
+- "itching for more" / "itching to go"
+- "took the plunge"
+- "pretty stout" / "pretty sweet"
+- "go out with a bang"
+- "jonesing for"
+- "floored"
+- "sweet" (for impressive things)
+- "sucker for"
+- "the way I see it"
+- "lol" (occasionally, in-line)
+
+### Transition / Filler Words
+
+- "Well," to start a post or paragraph
+- "So," to advance a narrative
+- "Anyway," to change topics
+- "Turns out" to reveal a result
+
+### Technical Jargon
+
+Matt uses jargon freely but defines it on first use, usually with a parenthetical: "Local Hobby Shop (LHS)" / "Free Lossless Audio Codec (flac)". He focuses on practical results over theory — "I don't know how it works, but it does" is fine.
+
+### Words/Phrases to AVOID (AI tells)
+
+- "durable" (as in "durable skill")
+- "orchestrating"
+- "converge"
+- "membrane" (as metaphor)
+- "landscape" (as in "the AI landscape")
+- "leverage" (as verb)
+- "nuanced"
+- "it's worth noting that"
+- "the ratio tracks with"
+- Any phrase that sounds like a conference talk abstract
+
+## Recurring Verbal Patterns
+
+These are Matt's go-to constructions:
+
+- **"I have always been a [fan/sucker for]..."** — Common opener
+- **"More to follow..." / "Stay tuned..."** — Signature closer
+- **"If you are looking for... [recommendation]"** — Reader-directed advice
+- **"Here are some [pictures/pics/photos]:"** — Image introduction
+- **"This is a [great/classic/must-see]..."** — Endorsement
+- **"(don't ask)" / "Don't ask me why"** — Self-deprecating aside
+- **"The way I see it..."** — Personal framing
+
+## Opening Patterns
+
+Matt starts posts several ways — vary these:
+
+1. **Personal statement:** "I have always been a fan of..." / "I have been looking around for..."
+2. **Rhetorical question:** "Who doesn't like live music?" / "Are you sick of playing target practice?"
+3. **Time marker:** "It has been [X years] since..." (especially for site updates)
+4. **Dramatic hook:** "I learned two very valuable lesson today..."
+5. **Self-aware humor:** "Whoa, easy on the Acronyms..." / "I know this contradicts my recent post..."
+
+## Closing Patterns
+
+1. **Call to action:** "give MOO cards a try" / "don't wait another day... get it done!"
+2. **Continuation promise:** "More to follow..." / "Stay tuned..."
+3. **Punchy final line:** "I am quite happy." / "Just remember... time is relative."
+4. **Circle back to the opening** — Restating the lesson or thesis from the intro
+
+## Formatting
+
+- **Headers** — H2/H3 in longer tutorial posts. Short posts often have no headers at all.
+- **Lists** — Bullet lists for specs and gear. Numbered lists for steps. Bold labels for Pros/Cons/Summary sections.
+- **Bold** — For section labels, product names, emphasis on key words
+- **Italic** — Sparingly, for disclaimers or asides
+- **Code blocks** — In technical tutorials, with language specified
+- **Images** — Introduced casually: "Here are some pics:" / "look what I did..."
+- **Links** — Woven naturally into sentences, not footnoted
+
+## Content Structure by Post Type
+
+### Product Review
+Intro with personal need → research process → purchase decision → first impressions → Pros/Cons/Conclusion
+
+### Tutorial
+Problem statement → solution → step-by-step instructions → screenshots → summary
+
+### Trip Report
+Where we went → what we did (chronological) → highlights → photos → recommendation
+
+### Website Update
+Time since last update → what changed → what's new → "Homage" screenshot tradition
+
+### Short Reaction / Share
+One sentence or image + brief comment. Let the content speak for itself.
+
+### Essay / Opinion
+Thesis question → argument with examples → call to action
+
+## The Imperfection Factor
+
+Matt's posts are not immaculate. They have:
+
+- Occasional typos ("controler," "truely," "nothting") — don't add them on purpose, but don't over-polish either
+- Comma splices in narrative passages
+- Missing words or slightly awkward phrasing that a human wouldn't catch on re-read
+- Uneven section lengths — some sections are a sentence, others are three paragraphs
+- Inconsistent formatting across posts (and that's fine)
+
+The goal is writing that feels like a real person sat down and wrote it in one sitting, re-read it once, and hit publish. Not a draft committee artifact.
+
+---
+
+*This guide was created by analyzing all human-written posts on mrmatt.io (2007–2017, plus the 2026 website update) and identifying the patterns that make Matt's voice distinct from AI-generated content.*


### PR DESCRIPTION
## Summary
- Add `WRITING-STYLE.md` — comprehensive writing voice guide derived from analyzing all human-written posts (2007–2017), covering tone, punctuation habits (ellipses over em dashes), vocabulary, post structure templates, and the "imperfection factor" that distinguishes Matt's voice from AI-generated content
- Add `ILLUSTRATION-STYLE.md` — editorial illustration style guide capturing the monochrome pen-and-ink style (cross-hatching, stippling, small human figure, conceptual metaphors) established by the Membrane and Autoresearch blog post images
- Reference both guides from `CLAUDE.md` so future content workflows pick them up automatically

## Test plan
- [ ] Both files render correctly on GitHub
- [ ] Writing guide is referenced in future blog post workflows
- [ ] Illustration guide is referenced when creating new post illustrations

Generated with [Claude Code](https://claude.com/claude-code)