### PR TITLE
fix: increase LCP chart height for readability

### DIFF
--- a/content/posts/2026-03_autoresearch-webperf.md
+++ b/content/posts/2026-03_autoresearch-webperf.md
@@ -42,7 +42,7 @@ The agent was allowed to modify eight files: `extend_head.html` (resource hints)
 
 ### LCP over 200 experiments
 
-<div style="position:relative; width:100%; aspect-ratio:16/9; margin:2rem 0;">
+<div style="position:relative; width:100%; aspect-ratio:4/3; margin:2rem 0;">
 <canvas id="lcp-timeline"></canvas>
 </div>
 


### PR DESCRIPTION
## Summary
- Increase LCP over 200 experiments chart aspect ratio from `16/9` to `4/3` (~34% taller)
- The previous ratio made the 200-point timeline too vertically compressed to read comfortably

## Test plan
- [x] Hugo builds with no errors
- [x] LCP chart renders taller on localhost
- [x] No overflow or clipping on the chart
- [x] Other charts on the page unaffected

Generated with [Claude Code](https://claude.com/claude-code)