### PR TITLE
fix: dark mode toggle not clickable

### DIFF
--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -132,6 +132,7 @@ h6 { font-size: 1rem; line-height: 1.6; letter-spacing: 0; margin-bottom: 0.25em
     position: absolute;
     top: 2rem;
     right: 0;
+    z-index: 1;
     contain: layout style;
 }
 


### PR DESCRIPTION
## Summary
- The theme toggle button (`.theme-toggle-wrap`) is absolutely positioned inside the header, but the `.nav` element's padding box overlaps it
- Without an explicit `z-index`, the nav intercepts clicks before they reach the toggle button
- Adds `z-index: 1` to `.theme-toggle-wrap` to ensure the toggle is always above the nav layer

## Test plan
- [x] Click the moon/sun toggle icon in the header — dark mode should activate
- [x] Verify the toggle works on homepage, blog posts, and other pages
- [x] Hugo builds with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)