### PR TITLE
fix: defer Chart.js init for correct chart heights

### DIFF
--- a/content/posts/2026-03_autoresearch-webperf.md
+++ b/content/posts/2026-03_autoresearch-webperf.md
@@ -671,7 +671,10 @@ The full experiment log, evaluation harness, and agent instructions are [on GitH
         });
     }
 
-    renderCharts();
+    /* Defer to next frame so CSS aspect-ratio is computed before Chart.js reads container height */
+    requestAnimationFrame(function() {
+        renderCharts();
+    });
     new MutationObserver(function() { location.reload(); })
         .observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
 })();

--- a/content/posts/2026-03_camera-gear-timeline.md
+++ b/content/posts/2026-03_camera-gear-timeline.md
@@ -66,7 +66,10 @@ For the deep dive into what all that EXIF data reveals about shooting patterns, 
 (function() {
     fetch('/data/camera-timeline.json')
         .then(function(r) { return r.json(); })
-        .then(function(data) { renderCharts(data); });
+        .then(function(data) {
+            /* Defer to next frame so CSS aspect-ratio is computed before Chart.js reads container height */
+            requestAnimationFrame(function() { renderCharts(data); });
+        });
 
     /* Cameras I actually owned (exclude friends' shared photos) */
     var NOT_OWNED = [

--- a/content/posts/2026-03_photography-by-the-numbers.md
+++ b/content/posts/2026-03_photography-by-the-numbers.md
@@ -104,7 +104,10 @@ See the full gear timeline in [Every Camera I've Ever Owned](/posts/camera-gear-
 (function() {
     fetch('/data/photo-stats.json')
         .then(function(r) { return r.json(); })
-        .then(function(data) { renderCharts(data); });
+        .then(function(data) {
+            /* Defer to next frame so CSS aspect-ratio is computed before Chart.js reads container height */
+            requestAnimationFrame(function() { renderCharts(data); });
+        });
 
     function renderCharts(data) {
         var isDark = document.documentElement.getAttribute('data-theme') === 'dark';


### PR DESCRIPTION
## Summary
- Chart.js was reading container dimensions before CSS `aspect-ratio` was computed, causing compressed charts on Cloudflare Pages but not locally
- Wrap `renderCharts()` in `requestAnimationFrame` across all 3 chart posts so one layout pass completes before Chart.js reads container height
- Affects: autoresearch-webperf, photography-by-the-numbers, camera-gear-timeline

## Test plan
- [x] Hugo builds with no errors
- [x] All charts render at correct height locally
- [x] Charts still respond to dark/light theme toggle
- [ ] Deployed charts match local chart heights

Generated with [Claude Code](https://claude.com/claude-code)