### PR TITLE
fix: compute explicit pixel heights for chart containers

### DIFF
--- a/content/posts/2026-03_autoresearch-webperf.md
+++ b/content/posts/2026-03_autoresearch-webperf.md
@@ -671,10 +671,17 @@ The full experiment log, evaluation harness, and agent instructions are [on GitH
         });
     }
 
-    /* Defer to next frame so CSS aspect-ratio is computed before Chart.js reads container height */
-    requestAnimationFrame(function() {
-        renderCharts();
+    /* Set explicit pixel heights on chart containers — CSS aspect-ratio alone
+       is unreliable when Chart.js reads dimensions on the deployed site */
+    document.querySelectorAll('canvas[id]').forEach(function(c) {
+        var p = c.parentNode;
+        var ar = p.style.aspectRatio || getComputedStyle(p).aspectRatio;
+        if (ar && ar !== 'auto') {
+            var parts = ar.split('/');
+            p.style.height = Math.round(p.offsetWidth * parseInt(parts[1]) / parseInt(parts[0])) + 'px';
+        }
     });
+    renderCharts();
     new MutationObserver(function() { location.reload(); })
         .observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
 })();

--- a/content/posts/2026-03_camera-gear-timeline.md
+++ b/content/posts/2026-03_camera-gear-timeline.md
@@ -67,8 +67,17 @@ For the deep dive into what all that EXIF data reveals about shooting patterns, 
     fetch('/data/camera-timeline.json')
         .then(function(r) { return r.json(); })
         .then(function(data) {
-            /* Defer to next frame so CSS aspect-ratio is computed before Chart.js reads container height */
-            requestAnimationFrame(function() { renderCharts(data); });
+            /* Set explicit pixel heights on chart containers — CSS aspect-ratio alone
+               is unreliable when Chart.js reads dimensions on the deployed site */
+            document.querySelectorAll('canvas[id]').forEach(function(c) {
+                var p = c.parentNode;
+                var ar = p.style.aspectRatio || getComputedStyle(p).aspectRatio;
+                if (ar && ar !== 'auto') {
+                    var parts = ar.split('/');
+                    p.style.height = Math.round(p.offsetWidth * parseInt(parts[1]) / parseInt(parts[0])) + 'px';
+                }
+            });
+            renderCharts(data);
         });
 
     /* Cameras I actually owned (exclude friends' shared photos) */

--- a/content/posts/2026-03_photography-by-the-numbers.md
+++ b/content/posts/2026-03_photography-by-the-numbers.md
@@ -105,8 +105,17 @@ See the full gear timeline in [Every Camera I've Ever Owned](/posts/camera-gear-
     fetch('/data/photo-stats.json')
         .then(function(r) { return r.json(); })
         .then(function(data) {
-            /* Defer to next frame so CSS aspect-ratio is computed before Chart.js reads container height */
-            requestAnimationFrame(function() { renderCharts(data); });
+            /* Set explicit pixel heights on chart containers — CSS aspect-ratio alone
+               is unreliable when Chart.js reads dimensions on the deployed site */
+            document.querySelectorAll('canvas[id]').forEach(function(c) {
+                var p = c.parentNode;
+                var ar = p.style.aspectRatio || getComputedStyle(p).aspectRatio;
+                if (ar && ar !== 'auto') {
+                    var parts = ar.split('/');
+                    p.style.height = Math.round(p.offsetWidth * parseInt(parts[1]) / parseInt(parts[0])) + 'px';
+                }
+            });
+            renderCharts(data);
         });
 
     function renderCharts(data) {


### PR DESCRIPTION
## Summary
- CSS `aspect-ratio` alone fails on the deployed site — Chart.js reads container dimensions before aspect-ratio takes effect
- Now JavaScript reads each container's `aspect-ratio` value and sets an explicit pixel `height` before Chart.js initializes
- Applies to all 3 chart posts: autoresearch, photography-by-the-numbers, camera-gear-timeline

## Test plan
- [x] Hugo builds with no errors
- [x] All charts render at correct height locally
- [x] Charts respond to dark/light theme toggle
- [ ] Deployed charts match local chart heights (the actual fix)

Generated with [Claude Code](https://claude.com/claude-code)