### PR TITLE
fix: use padding-bottom for reliable chart sizing

### DIFF
--- a/content/posts/2026-03_autoresearch-webperf.md
+++ b/content/posts/2026-03_autoresearch-webperf.md
@@ -42,8 +42,8 @@ The agent was allowed to modify eight files: `extend_head.html` (resource hints)
 
 ### LCP over 200 experiments
 
-<div style="position:relative; width:100%; aspect-ratio:3/2; margin:2rem 0;">
-<canvas id="lcp-timeline"></canvas>
+<div style="position:relative; width:100%; padding-bottom:66.67%; margin:2rem 0;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="lcp-timeline"></canvas>
 </div>
 
 The trajectory tells the story. The first few experiments delivered the biggest gains, then returns diminished. The downward staircase pattern is characteristic of optimization -- early wins are large and obvious, later wins are marginal and noisy. The spikes are failed experiments that got discarded.
@@ -53,11 +53,11 @@ Baseline was 2,638ms. The agent got it to a stable 2,109ms -- a **20% reduction*
 ### Experiment outcomes
 
 <div style="display:grid; grid-template-columns:1fr 1fr; gap:1.5rem; margin:2rem 0;">
-<div style="position:relative; width:100%; aspect-ratio:1/1;">
-<canvas id="outcomes-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:100%;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="outcomes-chart"></canvas>
 </div>
-<div style="position:relative; width:100%; aspect-ratio:1/1;">
-<canvas id="category-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:100%;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="category-chart"></canvas>
 </div>
 </div>
 
@@ -65,8 +65,8 @@ Of 200 experiments, 147 were kept (74%) and 47 discarded (23%). Four crashed the
 
 ### What actually moved the needle
 
-<div style="position:relative; width:100%; aspect-ratio:3/2; margin:2rem 0;">
-<canvas id="top-wins"></canvas>
+<div style="position:relative; width:100%; padding-bottom:66.67%; margin:2rem 0;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="top-wins"></canvas>
 </div>
 
 The biggest single improvement was **adding `content-visibility: auto`** to gallery thumbnails (-222ms). This told the browser to skip rendering off-screen images entirely, which freed up main-thread time during the initial paint.
@@ -77,8 +77,8 @@ Image quality reduction (q80 → q60 on thumbnails) and matching the preload to 
 
 ### The surprise: preloads can hurt
 
-<div style="position:relative; width:100%; aspect-ratio:3/2; margin:2rem 0;">
-<canvas id="preload-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:66.67%; margin:2rem 0;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="preload-chart"></canvas>
 </div>
 
 Resource preloading was the most volatile optimization category. The agent discovered that **removing** the font preload saved 146ms, while **removing** the gallery image preload cost 527ms. Preloading three thumbnails instead of one caused contention and added 72ms. Adding `fetchpriority=high` to the font preload added 149ms.
@@ -87,16 +87,16 @@ On a throttled 4G connection, every preload competes for the same limited bandwi
 
 ### Build size vs. LCP
 
-<div style="position:relative; width:100%; aspect-ratio:3/2; margin:2rem 0;">
-<canvas id="size-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:66.67%; margin:2rem 0;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="size-chart"></canvas>
 </div>
 
 Build size and LCP had almost no correlation. The site grew from ~700MB to ~949MB (from accumulated experimental CSS and config), then dropped to ~689MB after a clean rebuild -- with no effect on LCP. Most of the size is in processed images, which Hugo caches aggressively. The LCP improvements came entirely from resource loading strategy and rendering hints, not from reducing bytes.
 
 ### The noise problem
 
-<div style="position:relative; width:100%; aspect-ratio:3/2; margin:2rem 0;">
-<canvas id="noise-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:66.67%; margin:2rem 0;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="noise-chart"></canvas>
 </div>
 
 Lighthouse scores on localhost are noisy. The same unchanged site can swing up to ±370ms between runs. The agent dealt with this by noting when results seemed noisy (e.g., "1961/2333 noisy") and sometimes running a second evaluation to confirm. Several experiments were kept or discarded on what was likely noise.
@@ -671,16 +671,6 @@ The full experiment log, evaluation harness, and agent instructions are [on GitH
         });
     }
 
-    /* Set explicit pixel heights on chart containers — CSS aspect-ratio alone
-       is unreliable when Chart.js reads dimensions on the deployed site */
-    document.querySelectorAll('canvas[id]').forEach(function(c) {
-        var p = c.parentNode;
-        var ar = p.style.aspectRatio || getComputedStyle(p).aspectRatio;
-        if (ar && ar !== 'auto') {
-            var parts = ar.split('/');
-            p.style.height = Math.round(p.offsetWidth * parseInt(parts[1]) / parseInt(parts[0])) + 'px';
-        }
-    });
     renderCharts();
     new MutationObserver(function() { location.reload(); })
         .observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });

--- a/content/posts/2026-03_camera-gear-timeline.md
+++ b/content/posts/2026-03_camera-gear-timeline.md
@@ -17,8 +17,8 @@ After [scanning 723GB of Google Takeout data](/posts/google-takeout-gallery-cura
 
 ### The timeline
 
-<div style="position:relative;width:100%;aspect-ratio:1/1;margin:2rem 0;">
-<canvas id="timeline-chart"></canvas>
+<div style="position:relative;width:100%;padding-bottom:100%;margin:2rem 0;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="timeline-chart"></canvas>
 </div>
 
 The pattern is clear: dedicated cameras dominated until around 2013, then phones took over completely. The transition wasn't gradual -- it was a cliff. Once the Samsung Galaxy Note II arrived, the Canon PowerShots and Nikon DSLRs collected dust.
@@ -35,8 +35,8 @@ The Pixel years run from 2016 to present. Google Pixel XL, 2 XL, 3 XL, 4 XL, 5, 
 
 ### Phone vs. dedicated camera
 
-<div style="position:relative;width:100%;aspect-ratio:5/6;margin:2rem 0;">
-<canvas id="category-chart"></canvas>
+<div style="position:relative;width:100%;padding-bottom:120%;margin:2rem 0;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="category-chart"></canvas>
 </div>
 
 The crossover happened around 2013. By 2018, dedicated cameras were effectively zero. Computational photography didn't just match optical quality -- it made the camera you always have with you the best camera.
@@ -66,19 +66,7 @@ For the deep dive into what all that EXIF data reveals about shooting patterns, 
 (function() {
     fetch('/data/camera-timeline.json')
         .then(function(r) { return r.json(); })
-        .then(function(data) {
-            /* Set explicit pixel heights on chart containers — CSS aspect-ratio alone
-               is unreliable when Chart.js reads dimensions on the deployed site */
-            document.querySelectorAll('canvas[id]').forEach(function(c) {
-                var p = c.parentNode;
-                var ar = p.style.aspectRatio || getComputedStyle(p).aspectRatio;
-                if (ar && ar !== 'auto') {
-                    var parts = ar.split('/');
-                    p.style.height = Math.round(p.offsetWidth * parseInt(parts[1]) / parseInt(parts[0])) + 'px';
-                }
-            });
-            renderCharts(data);
-        });
+        .then(function(data) { renderCharts(data); });
 
     /* Cameras I actually owned (exclude friends' shared photos) */
     var NOT_OWNED = [

--- a/content/posts/2026-03_photography-by-the-numbers.md
+++ b/content/posts/2026-03_photography-by-the-numbers.md
@@ -15,8 +15,8 @@ I scanned the EXIF headers of every JPEG across 15 Google Takeout zip files. Her
 
 ### Volume over time
 
-<div style="position:relative; width:100%; aspect-ratio:3/2; margin:2rem 0;">
-<canvas id="yearly-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:66.67%; margin:2rem 0;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="yearly-chart"></canvas>
 </div>
 
 The yearly photo count forms a bell curve peaking at 2015 with 13,816 photos. The ramp tracks predictable life events -- kids born, vacations, new cameras arriving every year or two. At the peak, I had five cameras active in a single year: phones, compacts, and a DSLR all competing for pocket space. The decline after 2015 is equally clear: one phone replaced everything, and the volume settled to a sustainable rhythm. The 2020 dip is exactly what you'd expect from a year spent mostly indoors.
@@ -24,11 +24,11 @@ The yearly photo count forms a bell curve peaking at 2015 with 13,816 photos. Th
 ### When I shoot
 
 <div style="display:grid; grid-template-columns:1fr 1fr; gap:1.5rem; margin:2rem 0;">
-<div style="position:relative; width:100%; aspect-ratio:1/1;">
-<canvas id="hourly-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:100%;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="hourly-chart"></canvas>
 </div>
-<div style="position:relative; width:100%; aspect-ratio:1/1;">
-<canvas id="dow-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:100%;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="dow-chart"></canvas>
 </div>
 </div>
 
@@ -36,24 +36,24 @@ Saturday at 10am is my golden hour. Weekends get twice the shooting volume of mi
 
 ### The heatmap
 
-<div style="position:relative; width:100%; aspect-ratio:3/2; margin:2rem 0;">
-<canvas id="heatmap-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:66.67%; margin:2rem 0;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="heatmap-chart"></canvas>
 </div>
 
 The pattern is clear: weekend mornings and afternoons are when I reach for the camera. The weekday rows are dim and uniform. Saturday and Sunday light up from mid-morning through late afternoon, with the strongest signal clustered around 9am to 3pm.
 
 ### People in photos
 
-<div style="position:relative; width:100%; aspect-ratio:3/2; margin:2rem 0;">
-<canvas id="people-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:66.67%; margin:2rem 0;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="people-chart"></canvas>
 </div>
 
 The percentage of photos containing people dropped from 70% in 2016 to under 2% after 2020. This could reflect Google's face detection metadata changing over time, or a genuine shift toward landscape and nature photography. Probably both. The early years are noisy because the sample sizes are small -- a few hundred photos per year makes each face detection hit or miss count for a lot.
 
 ### Where in the world
 
-<div style="position:relative; width:100%; aspect-ratio:3/2; margin:2rem 0;">
-<canvas id="gps-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:66.67%; margin:2rem 0;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="gps-chart"></canvas>
 </div>
 
 GPS data went from 0% in the pre-smartphone era to 91% in 2017, then drifted back down. The rise tracks smartphone adoption perfectly -- phones embed GPS coordinates by default, dedicated cameras don't. The decline after 2017 likely reflects tightening privacy settings and location permissions being turned off, plus occasional use of cameras without GPS radios.
@@ -61,14 +61,14 @@ GPS data went from 0% in the pre-smartphone era to 91% in 2017, then drifted bac
 ### The lens settings
 
 <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:1.5rem; margin:2rem 0;">
-<div style="position:relative; width:100%; aspect-ratio:1/1;">
-<canvas id="aperture-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:100%;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="aperture-chart"></canvas>
 </div>
-<div style="position:relative; width:100%; aspect-ratio:1/1;">
-<canvas id="focal-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:100%;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="focal-chart"></canvas>
 </div>
-<div style="position:relative; width:100%; aspect-ratio:1/1;">
-<canvas id="iso-time-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:100%;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="iso-time-chart"></canvas>
 </div>
 </div>
 
@@ -77,11 +77,11 @@ f/2.0 at 27mm. That's the phone sweet spot -- a moderately wide angle with a fas
 ### Resolution and exposure
 
 <div style="display:grid; grid-template-columns:1fr 1fr; gap:1.5rem; margin:2rem 0;">
-<div style="position:relative; width:100%; aspect-ratio:1/1;">
-<canvas id="resolution-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:100%;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="resolution-chart"></canvas>
 </div>
-<div style="position:relative; width:100%; aspect-ratio:1/1;">
-<canvas id="exposure-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:100%;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="exposure-chart"></canvas>
 </div>
 </div>
 
@@ -89,8 +89,8 @@ Resolution plateaued after the megapixel race ended. The jump from 4MP in 2003 t
 
 ### The full heartbeat
 
-<div style="position:relative; width:100%; aspect-ratio:3/2; margin:2rem 0;">
-<canvas id="monthly-chart"></canvas>
+<div style="position:relative; width:100%; padding-bottom:66.67%; margin:2rem 0;">
+<canvas style="position:absolute; inset:0; width:100%; height:100%;" id="monthly-chart"></canvas>
 </div>
 
 Zoom out from yearly averages and the real rhythm appears. Every spike is a trip, a holiday, a new baby, a Saturday morning at the park. The three busiest months -- May 2015, April 2018, April 2015 -- each cracked 1,700 photos. That's 55 to 65 photos a day, every day, for a month straight. The quiet valleys are just as telling: the gaps where life got busy, or the camera stayed in the drawer, or a global pandemic kept everyone indoors.
@@ -104,19 +104,7 @@ See the full gear timeline in [Every Camera I've Ever Owned](/posts/camera-gear-
 (function() {
     fetch('/data/photo-stats.json')
         .then(function(r) { return r.json(); })
-        .then(function(data) {
-            /* Set explicit pixel heights on chart containers — CSS aspect-ratio alone
-               is unreliable when Chart.js reads dimensions on the deployed site */
-            document.querySelectorAll('canvas[id]').forEach(function(c) {
-                var p = c.parentNode;
-                var ar = p.style.aspectRatio || getComputedStyle(p).aspectRatio;
-                if (ar && ar !== 'auto') {
-                    var parts = ar.split('/');
-                    p.style.height = Math.round(p.offsetWidth * parseInt(parts[1]) / parseInt(parts[0])) + 'px';
-                }
-            });
-            renderCharts(data);
-        });
+        .then(function(data) { renderCharts(data); });
 
     function renderCharts(data) {
         var isDark = document.documentElement.getAttribute('data-theme') === 'dark';


### PR DESCRIPTION
## Summary
- Replace CSS `aspect-ratio` with classic `padding-bottom` percentage trick for all Chart.js containers
- Canvas elements are now absolutely positioned within their containers
- Removed JS height calculation workarounds — sizing is now pure CSS
- `aspect-ratio` worked locally but failed on the deployed Cloudflare Pages site; `padding-bottom` is universally reliable
- Affects all 3 chart posts: autoresearch, photography-by-the-numbers, camera-gear-timeline

## Test plan
- [x] Hugo builds with no errors
- [x] All charts render at correct height on `hugo server` (no minify)
- [x] All charts render at correct height on `hugo server --minify`
- [x] Grid charts (1/1) render correctly in side-by-side layout
- [x] Charts respond to dark/light theme toggle
- [ ] Deployed charts on mrmatt.io match local chart heights

Generated with [Claude Code](https://claude.com/claude-code)